### PR TITLE
Fix indentation in tutorial code example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -283,7 +283,7 @@ repeatedly nag like this::
                 print('Can I play?')
                 await start_evt.wait(timeout=1)
                 break
-             except TimeoutError:
+            except TimeoutError:
 	        print('Wha!?!')
         try:
             print('Building the Millenium Falcon in Minecraft')


### PR DESCRIPTION
Try/Except indentation didn't match in the code snippet