### PR TITLE
Fix an error on Windows when no sockets are being select()'d

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -335,11 +335,12 @@ class Kernel(object):
         else:
             timeout = None
 
-        events = self._selector.select(timeout)
-        for key, mask in events:
-            task = key.data
-            self._selector.unregister(key.fileobj)
-            self._reschedule_task(task)
+        if self._selector.get_map():
+            events = self._selector.select(timeout)
+            for key, mask in events:
+                task = key.data
+                self._selector.unregister(key.fileobj)
+                self._reschedule_task(task)
 
         # Process sleeping tasks (if any)
         if self._sleeping:


### PR DESCRIPTION
This won't call select() if there are no sockets being checked, as on Windows this will raise a WindowsError(WSAEINVAL)
