### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,9 +90,9 @@ of the code:
         run(tcp_server('', 25000, echo_client))
 
 This is only a small sample of what's possible.  Read the `official documentation
-<https://curio.readthedocs.org>`_ for more in-depth coverage.  The `tutorial 
-<https://curio.readthedocs.org/en/latest/tutorial.html>`_ is a good starting point.
-The `howto <https://curio.readthedocs.org/en/latest/howto.html>`_ describes how
+<https://curio.readthedocs.io>`_ for more in-depth coverage.  The `tutorial 
+<https://curio.readthedocs.io/en/latest/tutorial.html>`_ is a good starting point.
+The `howto <https://curio.readthedocs.io/en/latest/howto.html>`_ describes how
 to carry out various tasks.
 
 Additional Features

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,5 +1,5 @@
 # A hello world program. From the Curio tutorial at
-# https://curio.readthedocs.org/en/latest/tutorial.html
+# https://curio.readthedocs.io/en/latest/tutorial.html
 #
 import curio
 import signal


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.