### PR TITLE
Close selector when shutting down resources

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -134,6 +134,10 @@ class Kernel(object):
             self._signal_sets = None
             self._default_signals = None
 
+        if self._selector:
+            self._selector.close()
+            self._selector = None
+
     # Main Kernel Loop
     # ----------
     def run(self, coro=None, *, shutdown=False):


### PR DESCRIPTION
I noticed that after running `curio.run()` a KQUEUE file descriptor would be held open by the Python process (I'm on OS X), effectively leaking them with multiple runs. I tracked it down to the `Kernel._selector` not being closed when shutting down.

Here's a terminal session illustrating the issue with lsof:
```
$ cat curio_shutdown.py 
import curio
curio.run(curio.sleep(1))
curio.run(curio.sleep(1000))
$ python3 curio_shutdown.py &
[1] 71835
$ lsof -p 71835 | grep KQUEUE
Python  71835 sterling    4u  KQUEUE                           count=0, state=0x8
Python  71835 sterling    5u  KQUEUE                           count=0, state=0x8
$ kill %1
[1]+  Terminated: 15          python3 curio_shutdown.py
$ 
$ # after applying fix
$ 
$ python3 curio_shutdown.py &
[1] 71851
$ lsof -p 71851 | grep KQUEUE
Python  71851 sterling    4u  KQUEUE                           count=0, state=0x8
$ kill %1
[1]+  Terminated: 15          python3 curio_shutdown.py
$ 
```