### PR TITLE
Split all examples as Python scripts

### DIFF
--- a/docs/examples/blocking_io.py
+++ b/docs/examples/blocking_io.py
@@ -1,0 +1,17 @@
+from curio import run, spawn, tcp_server
+
+async def echo_client(client, addr):
+    print('Connection from', addr)
+    while True:
+        data = await client.recv(1000)
+        if not data:
+            break
+
+        # Temporarily enter blocking mode and use as a normal socket
+        with client.blocking() as _client:
+            _client.sendall(data)
+
+    print('Connection closed')
+
+if __name__ == '__main__':
+    run(tcp_server('', 25000, echo_client))

--- a/docs/examples/blocking_io_in_thread.py
+++ b/docs/examples/blocking_io_in_thread.py
@@ -1,0 +1,17 @@
+from curio import run, spawn, tcp_server, run_in_thread
+
+async def echo_client(client, addr):
+    print('Connection from', addr)
+    while True:
+        data = await client.recv(1000)
+        if not data:
+            break
+
+        # Temporarily enter blocking mode
+        with client.blocking() as _client:
+            await run_in_thread(_client.sendall, data)
+
+    print('Connection closed')
+
+if __name__ == '__main__':
+    run(tcp_server('', 25000, echo_client))

--- a/docs/examples/getting_started.py
+++ b/docs/examples/getting_started.py
@@ -1,0 +1,11 @@
+# getting_started.py
+import curio
+
+async def countdown(n):
+    while n > 0:
+        print('T-minus', n)
+        await curio.sleep(1)
+        n -= 1
+
+if __name__ == '__main__':
+    curio.run(countdown(10))

--- a/docs/examples/intertask_communication.py
+++ b/docs/examples/intertask_communication.py
@@ -1,0 +1,23 @@
+import curio
+
+async def producer(queue):
+    for n in range(10):
+        await queue.put(n)
+    await queue.join()
+    print('Producer done')
+
+async def consumer(queue):
+    while True:
+        item = await queue.get()
+        print('Consumer got', item)
+        await queue.task_done()
+
+async def main():
+    q = curio.Queue()
+    prod_task = await curio.spawn(producer(q))
+    cons_task = await curio.spawn(consumer(q))
+    await prod_task.join()
+    await cons_task.cancel()
+
+if __name__ == '__main__':
+    curio.run(main())

--- a/docs/examples/managed_echo_server.py
+++ b/docs/examples/managed_echo_server.py
@@ -1,0 +1,37 @@
+import os
+import signal
+from curio import run, spawn, SignalSet, CancelledError, tcp_server, current_task
+
+clients = set()
+
+async def echo_client(client, addr):
+    task = await current_task()
+    clients.add(task)
+    print('Connection from', addr)
+    try:
+        while True:
+            data = await client.recv(1000)
+            if not data:
+                break
+            await client.sendall(data)
+        print('Connection closed')
+    except CancelledError:
+        await client.sendall(b'Server going down\n')
+    finally:
+        clients.remove(task)
+
+async def main(host, port):
+    while True:
+        async with SignalSet(signal.SIGHUP) as sigset:
+            print('Starting the server')
+            serv_task = await spawn(tcp_server(host, port, echo_client))
+            await sigset.wait()
+            print('Server shutting down')
+            await serv_task.cancel()
+
+            for task in list(clients):
+                await task.cancel()
+
+if __name__ == '__main__':
+    print('PID:', os.getpid())
+    run(main('', 25000))

--- a/docs/examples/several_tasks.py
+++ b/docs/examples/several_tasks.py
@@ -1,0 +1,27 @@
+# several_tasks.py
+import curio
+
+async def countdown(n):
+    while n > 0:
+        print('T-minus', n)
+        await curio.sleep(1)
+        n -= 1
+
+async def kid():
+    print('Building the Millenium Falcon in Minecraft')
+    await curio.sleep(1000)
+
+async def parent():
+    kid_task = await curio.spawn(kid())
+    await curio.sleep(5)
+
+    print("Let's go")
+    count_task = await curio.spawn(countdown(10))
+    await count_task.join()
+
+    print("We're leaving!")
+    await kid_task.join()
+    print('Leaving')
+
+if __name__ == '__main__':
+    curio.run(parent())

--- a/docs/examples/simple_echo_server.py
+++ b/docs/examples/simple_echo_server.py
@@ -1,0 +1,26 @@
+from curio import run, spawn
+from curio.socket import *
+
+async def echo_server(address):
+    sock = socket(AF_INET, SOCK_STREAM)
+    sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+    sock.bind(address)
+    sock.listen(5)
+    print('Server listening at', address)
+    async with sock:
+        while True:
+            client, addr = await sock.accept()
+            await spawn(echo_client(client, addr))
+
+async def echo_client(client, addr):
+    print('Connection from', addr)
+    async with client:
+        while True:
+            data = await client.recv(1000)
+            if not data:
+                break
+            await client.sendall(data)
+    print('Connection closed')
+
+if __name__ == '__main__':
+    run(echo_server(('', 25000)))

--- a/docs/examples/simple_http_client.py
+++ b/docs/examples/simple_http_client.py
@@ -1,0 +1,18 @@
+import curio
+
+async def main():
+    sock = await curio.open_connection('www.python.org', 80)
+    async with sock:
+        await sock.sendall(b'GET / HTTP/1.0\r\nHost: www.python.org\r\n\r\n')
+        chunks = []
+        while True:
+            chunk = await sock.recv(10000)
+            if not chunk:
+                break
+            chunks.append(chunk)
+
+    response = b''.join(chunks)
+    print(response.decode('latin-1'))
+
+if __name__ == '__main__':
+    curio.run(main())

--- a/docs/examples/simple_https_client.py
+++ b/docs/examples/simple_https_client.py
@@ -1,0 +1,20 @@
+import curio
+
+async def main():
+    sock = await curio.open_connection('www.python.org', 443,
+                                       ssl=True,
+                                       server_hostname='www.python.org')
+    async with sock:
+        await sock.sendall(b'GET / HTTP/1.0\r\nHost: www.python.org\r\n\r\n')
+        chunks = []
+        while True:
+            chunk = await sock.recv(10000)
+            if not chunk:
+                break
+            chunks.append(chunk)
+
+    response = b''.join(chunks)
+    print(response.decode('latin-1'))
+
+if __name__ == '__main__':
+    curio.run(main())

--- a/docs/examples/simple_ssl_server.py
+++ b/docs/examples/simple_ssl_server.py
@@ -1,0 +1,31 @@
+import curio
+from curio import ssl
+import time
+
+KEYFILE = 'privkey_rsa'       # Private key
+CERTFILE = 'certificate.crt'  # Server certificate
+
+async def handler(client, addr):
+    client_f = client.as_stream()
+
+    # Read the HTTP request
+    async for line in client_f:
+        line = line.strip()
+        if not line:
+            break
+        print(line)
+
+    # Send a response
+    await client_f.write(
+        b'''HTTP/1.0 200 OK\r
+        Content-type: text/plain\r
+        \r
+        If you're seeing this, it probably worked. Yay!
+        ''')
+    await client_f.write(time.asctime().encode('ascii'))
+    await client.close()
+
+if __name__ == '__main__':
+    ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ssl_context.load_cert_chain(certfile=CERTFILE, keyfile=KEYFILE)
+    curio.run(curio.tcp_server('', 10000, handler, ssl=ssl_context))

--- a/docs/examples/simple_subprocess.py
+++ b/docs/examples/simple_subprocess.py
@@ -1,0 +1,11 @@
+from curio import subprocess
+import curio
+
+async def main():
+    p = subprocess.Popen(['ping', 'www.python.org'],
+                         stdout=subprocess.PIPE)
+    async for line in p.stdout:
+        print('Got:', line.decode('ascii'), end='')
+
+if __name__ == '__main__':
+    curio.run(main())

--- a/docs/examples/stream_echo_server.py
+++ b/docs/examples/stream_echo_server.py
@@ -1,0 +1,14 @@
+from curio import run, tcp_server
+
+async def echo_client(client, addr):
+    print('Connection from', addr)
+    s = client.as_stream()
+    while True:
+        data = await s.read(1000)
+        if not data:
+            break
+        await s.write(data)
+    print('Connection closed')
+
+if __name__ == '__main__':
+    run(tcp_server('', 25000, echo_client))

--- a/docs/examples/stream_echo_server_with_async_for.py
+++ b/docs/examples/stream_echo_server_with_async_for.py
@@ -1,0 +1,12 @@
+from curio import run, tcp_server
+
+async def echo_client(client, addr):
+    print('Connection from', addr)
+    s = client.as_stream()
+    async for line in s:
+        await s.write(line)
+    print('Connection closed')
+
+if __name__ == '__main__':
+    run(tcp_server('', 25000, echo_client))
+

--- a/docs/examples/subprocess_check_output.py
+++ b/docs/examples/subprocess_check_output.py
@@ -1,0 +1,11 @@
+import curio
+from curio import subprocess
+
+async def main():
+    try:
+        out = await subprocess.check_output(['netstat', '-a'])
+    except subprocess.CalledProcessError as e:
+        print('It failed!', e)
+
+if __name__ == '__main__':
+    curio.run(main())

--- a/docs/examples/task_synchronization.py
+++ b/docs/examples/task_synchronization.py
@@ -1,0 +1,37 @@
+import curio
+
+from getting_started import countdown
+
+start_evt = curio.Event()
+
+async def kid():
+    print('Can I play?')
+    await start_evt.wait()
+    try:
+        print('Building the Millenium Falcon in Minecraft')
+        await curio.sleep(1000)
+    except curio.CancelledError:
+        print('Fine. Saving my work.')
+
+async def parent():
+    kid_task = await curio.spawn(kid())
+    await curio.sleep(5)
+
+    print('Yes, go play')
+    await start_evt.set()
+    await curio.sleep(5)
+
+    print("Let's go")
+    count_task = await curio.spawn(countdown(10))
+    await count_task.join()
+
+    print("We're leaving!")
+    try:
+        await curio.timeout_after(10, kid_task.join())
+    except curio.TaskTimeout:
+        print('I warned you!')
+        await kid_task.cancel()
+    print('Leaving!')
+
+if __name__ == '__main__':
+    curio.run(parent())

--- a/docs/examples/with_signals.py
+++ b/docs/examples/with_signals.py
@@ -1,0 +1,29 @@
+import signal, os
+
+import curio
+
+from task_synchronization import countdown, kid, start_evt
+
+async def parent():
+    print('Parent PID', os.getpid())
+    kid_task = await curio.spawn(kid())
+    await curio.sleep(5)
+
+    print('Yes, go play')
+    await start_evt.set()
+
+    await curio.SignalSet(signal.SIGHUP).wait()
+
+    print("Let's go")
+    count_task = await curio.spawn(countdown(10))
+    await count_task.join()
+    print("We're leaving!")
+    try:
+        await curio.timeout_after(10, kid_task.join())
+    except curio.TaskTimeout:
+        print('I warned you!')
+        await kid_task.cancel()
+    print('Leaving!')
+
+if __name__ == '__main__':
+    curio.run(parent())


### PR DESCRIPTION
Hi,

To be easier to play with examples for newcomers, I've splitted all examples as Python scripts.
It permits to launch examples directly on the computer.

BTW, thanks a lot about the documentation, especially about tutorial and FAQ, it's well architectured.

As permitted by the 3-clause BSD license, I want to re-use the architecture for a new AsyncIO tutorial and FAQ. Obviously, I'll keep a reference to your work.

Have a nice week-end.