### PR TITLE
Make the examples a little more accessible

### DIFF
--- a/examples/conn.py
+++ b/examples/conn.py
@@ -19,4 +19,7 @@ async def main():
 
 
 if __name__ == '__main__':
-    curio.run(main())
+    try:
+        curio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/examples/echoserv.py
+++ b/examples/echoserv.py
@@ -25,4 +25,7 @@ async def echo_client(client):
     print('Connection closed')
 
 if __name__ == '__main__':
-     run(echo_server(('',25000)))
+    try:
+        run(echo_server(('', 25000)))
+    except KeyboardInterrupt:
+        pass

--- a/examples/echoserv2.py
+++ b/examples/echoserv2.py
@@ -23,4 +23,8 @@ async def echo_client(client):
     print('Connection closed')
 
 if __name__ == '__main__':
-     run(echo_server(('',25000)))
+    try:
+        run(echo_server(('',25000)))
+    except KeyboardInterrupt:
+        pass
+

--- a/examples/echoserv3.py
+++ b/examples/echoserv3.py
@@ -14,4 +14,7 @@ async def echo_client(client, addr):
     print('Connection closed')
 
 if __name__ == '__main__':
-    run(tcp_server('', 25000, echo_client))
+    try:
+        run(tcp_server('', 25000, echo_client))
+    except KeyboardInterrupt:
+        pass

--- a/examples/echoserv4.py
+++ b/examples/echoserv4.py
@@ -13,4 +13,7 @@ async def echo_client(client, addr):
     await s.close()
 
 if __name__ == '__main__':
-    run(tcp_server('', 25000, echo_client))
+    try:
+        run(tcp_server('', 25000, echo_client))
+    except KeyboardInterrupt:
+        pass

--- a/examples/echoserv5.py
+++ b/examples/echoserv5.py
@@ -34,4 +34,7 @@ async def main(host, port):
                 await task.cancel()
 
 if __name__ == '__main__':
-    run(main('', 25000))
+    try:
+        run(main('', 25000))
+    except KeyboardInterrupt:
+        pass

--- a/examples/fibserve.py
+++ b/examples/fibserve.py
@@ -24,7 +24,10 @@ async def fib_handler(client, addr):
     await client.close()
 
 if __name__ == '__main__':
-    run(tcp_server('', 25000, fib_handler))
+    try:
+        run(tcp_server('', 25000, fib_handler))
+    except KeyboardInterrupt:
+        pass
 
 
 

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -57,4 +57,7 @@ async def parent():
     print("Leaving!")
 
 if __name__ == '__main__':
-    curio.run(parent(), with_monitor=True)
+    try:
+        curio.run(parent(), with_monitor=True)
+    except KeyboardInterrupt:
+        pass

--- a/examples/pinger.py
+++ b/examples/pinger.py
@@ -9,4 +9,7 @@ async def main():
         print('Got:', line.decode('ascii'), end='')
 
 if __name__ == '__main__':
-    curio.run(main())
+    try:
+        curio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/examples/prodcons.py
+++ b/examples/prodcons.py
@@ -24,4 +24,7 @@ async def main():
     await cons_task.cancel()
 
 if __name__ == '__main__':
-    curio.run(main())
+    try:
+        curio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/examples/ssl_echo.py
+++ b/examples/ssl_echo.py
@@ -2,12 +2,13 @@
 #
 # An example of a simple SSL echo server.   Use ssl_echo_client.py to test.
 
+import os
 import curio
 from curio import ssl
 from curio import network
 
-KEYFILE = "ssl_test_rsa"    # Private key
-CERTFILE = "ssl_test.crt"   # Certificate (self-signed)
+KEYFILE = os.path.dirname(__file__) + "/ssl_test_rsa"    # Private key
+CERTFILE = os.path.dirname(__file__) + "/ssl_test.crt"   # Certificate (self-signed)
 
 async def handle(client, addr):
     print('Connection from', addr)
@@ -22,5 +23,9 @@ async def handle(client, addr):
 if __name__ == '__main__':
     ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
     ssl_context.load_cert_chain(certfile=CERTFILE, keyfile=KEYFILE)
-    curio.run(network.tcp_server('', 10000, handle, ssl=ssl_context))
+    try:
+        curio.run(network.tcp_server('', 10000, handle, ssl=ssl_context))
+    except KeyboardInterrupt:
+        pass
+
 

--- a/examples/ssl_echo_client.py
+++ b/examples/ssl_echo_client.py
@@ -21,4 +21,7 @@ async def main(host, port):
     await sock.close()
 
 if __name__ == '__main__':
-    curio.run(main('localhost', 10000))
+    try:
+        curio.run(main('localhost', 10000))
+    except KeyboardInterrupt:
+        pass

--- a/examples/ssl_http.py
+++ b/examples/ssl_http.py
@@ -2,12 +2,13 @@
 #
 # An example of a simple SSL server.  To test, connect via browser
 
+import os
 import curio
 from curio import ssl
 import time
 
-KEYFILE = "ssl_test_rsa"    # Private key
-CERTFILE = "ssl_test.crt"   # Certificate (self-signed)
+KEYFILE = os.path.dirname(__file__) + "/ssl_test_rsa"    # Private key
+CERTFILE = os.path.dirname(__file__) + "/ssl_test.crt"   # Certificate (self-signed)
 
 async def handler(client, addr):
     s = client.as_stream()
@@ -30,4 +31,7 @@ if __name__ == '__main__':
     ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
     ssl_context.load_cert_chain(certfile=CERTFILE, keyfile=KEYFILE)
     print('Connect to https://localhost:10000 to see if it works')
-    curio.run(curio.tcp_server('', 10000, handler, ssl=ssl_context))
+    try:
+        curio.run(curio.tcp_server('', 10000, handler, ssl=ssl_context))
+    except KeyboardInterrupt:
+        pass

--- a/examples/udp_echo.py
+++ b/examples/udp_echo.py
@@ -14,4 +14,7 @@ async def main(addr):
         await sock.sendto(data, addr)
 
 if __name__ == '__main__':
-    curio.run(main(('', 26000)))
+    try:
+        curio.run(main(('', 26000)))
+    except KeyboardInterrupt:
+        pass

--- a/examples/udp_echo_client.py
+++ b/examples/udp_echo_client.py
@@ -17,4 +17,7 @@ async def main(addr):
     await sock.close()
 
 if __name__ == '__main__':
-    curio.run(main(('localhost', 26000)))
+    try:
+        curio.run(main(('localhost', 26000)))
+    except KeyboardInterrupt:
+        pass

--- a/examples/unix_echo.py
+++ b/examples/unix_echo.py
@@ -17,5 +17,7 @@ if __name__ == '__main__':
           os.remove('/tmp/curiounixecho')
      except:
           pass
-     run(unix_server('/tmp/curiounixecho', echo_handler))
-          
+     try:
+         run(unix_server('/tmp/curiounixecho', echo_handler))
+     except KeyboardInterrupt:
+          pass

--- a/examples/unix_echo_client.py
+++ b/examples/unix_echo_client.py
@@ -15,4 +15,7 @@ async def main(addr):
     await sock.close()
 
 if __name__ == '__main__':
-    curio.run(main('/tmp/curiounixecho'))
+    try:
+        curio.run(main('/tmp/curiounixecho'))
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
Please excuse the unsolicited pull request. I understand that this is a personal preference and I will totally understand if the pull request is denied.

Catch KeyboardInterrupt to not make the user think an error occurred when killing the server with CTRL+c
Make SSL cert and key file locations absolute paths to be able to run the example from a different directory