### PR TITLE
Task-local storage

### DIFF
--- a/curio/__init__.py
+++ b/curio/__init__.py
@@ -11,6 +11,7 @@ from .queue import *
 from .workers import *
 from .network import *
 from .file import *
+from .tls import *
 
 __all__ = [ *errors.__all__,
             *task.__all__,
@@ -21,4 +22,5 @@ __all__ = [ *errors.__all__,
             *workers.__all__,
             *network.__all__,
             *file.__all__,
+            *tls.__all__,
            ]

--- a/curio/task.py
+++ b/curio/task.py
@@ -17,7 +17,7 @@ class Task(object):
         'id', 'daemon', 'coro', '_send', '_throw', 'cycles', 'state',
         'cancel_func', 'future', 'sleep', 'timeout', 'exc_info', 'next_value',
         'next_exc', 'joining', 'cancelled', 'terminated', '_last_io', '_deadlines',
-        '__weakref__',
+        'task_local_storage', '__weakref__',
         )
     _lastid = 1
 
@@ -40,6 +40,7 @@ class Task(object):
         self.joining = None        # Optional set of tasks waiting to join with this one
         self.cancelled = False     # Cancelled?
         self.terminated = False    # Terminated?
+        self.task_local_storage = {} # Task local storage
         self._last_io = None       # Last I/O operation performed
         self._send = coro.send     # Bound coroutine methods
         self._throw = coro.throw

--- a/curio/tls.py
+++ b/curio/tls.py
@@ -50,7 +50,9 @@ __all__ = ["Local"]
 # An unusual feature of this implementation (and our main deviation from
 # threading.Local) is that we implement *TLS inheritance*, i.e., when you
 # spawn a new task, then all TLS values set in the parent task are (shallowly)
-# copied to the child task. This, again, allows us to preserve context
+# copied to the child task. This is a bit experimental, but very handy in
+# cases like when a request handler spawns some small short-lived worker tasks
+# as part of its processing and those want to do logging as well.
 
 import threading
 from contextlib import contextmanager

--- a/curio/tls.py
+++ b/curio/tls.py
@@ -1,0 +1,105 @@
+# curio/tls.py
+#
+# Task local storage
+
+__all__ = ["Local"]
+
+# Our public API is intentionally almost identical to that of threading.local:
+# the user allocates a curio.Local() object, and then can attach arbitrary
+# attributes to it. Reading one of these attributes later will return the last
+# value that was assigned to this attribute *by code running inside the same
+# Task*.
+#
+# Internally, each Task has an attribute .task_local_storage, which holds a
+# dict. This dict has one entry for each Local object that has been accessed
+# from this task context (i.e. entries here are lazily allocated), keyed by
+# the Local object instance itself:
+#
+#   {
+#     local_object_1: {
+#       "attr": value,
+#       "attr": value,
+#       ...
+#     },
+#     local_object_2: {
+#       "attr": value,
+#       "attr": value,
+#       ...
+#     },
+#     ...
+#   }
+#
+# From an async context one could access this dict with
+#
+#  (await curio.current_task()).task_local_storage
+#
+# But, we also want to be able to access this from synchronous context,
+# because one of the major use cases for this is tagging log messages with
+# context, and there are lots of legacy third-party libraries that use the
+# Python stdlib logging module. And it's synchronous. So if you want to
+# capture their logs and feed them into something better and more context-ful,
+# then you need to be able to get that context from synchronous-land.
+#
+# Therefore, whenever we resume a task, we stash a pointer to its
+# .task_local_storage dictionary in a global *thread*-local variable. Then
+# when we want to find a specific variable (local_obj.attr), we ultimately
+# look in
+#
+#  _current_task_local_storage.value[local_obj]["attr"]
+#
+# An unusual feature of this implementation (and our main deviation from
+# threading.Local) is that we implement *TLS inheritance*, i.e., when you
+# spawn a new task, then all TLS values set in the parent task are (shallowly)
+# copied to the child task. This, again, allows us to preserve context
+
+import threading
+from contextlib import contextmanager
+
+# The thread-local storage slot that points to the task-local storage dict for
+# whatever task is currently running.
+_current_task_local_storage = threading.local()
+_current_task_local_storage.value = None
+
+@contextmanager
+def _enable_tls_for(task):
+    # Using a full save/restore pattern here is a little paranoid, but
+    # safe. Even if someone does something silly like calling curio.run() from
+    # inside a curio coroutine.
+    old = _current_task_local_storage.value
+    try:
+        _current_task_local_storage.value = task.task_local_storage
+        yield
+    finally:
+        _current_task_local_storage.value = old
+
+# Called from _trap_spawn to implement TLS inheritance.
+def _copy_tls(parent, child):
+    # Make a shallow copy of the values associated with each Local object.
+    for local, values in parent.task_local_storage.items():
+        child.task_local_storage[local] = dict(values)
+
+# Given a Local object, find its associated dict in the current task (creating
+# it if necessary.)  Normally would be a method on Local, but __getattribute__
+# makes that annoying. This is the simplest workaround.
+def _local_dict(local):
+    return _current_task_local_storage.value.setdefault(local, {})
+
+class Local:
+    def __getattribute__(self, name):
+        try:
+            return _local_dict(self)[name]
+        except KeyError:
+            # "from None" preserves the context, but makes it hidden from
+            # tracebacks by default; see PEP 409
+            raise AttributeError(name) from None
+
+    def __setattr__(self, name, value):
+        _local_dict(self)[name] = value
+
+    def __delattr__(self, name):
+        try:
+            del _local_dict(self)[name]
+        except KeyError:
+            # "from None" preserves the context, but makes it hidden from
+            # tracebacks by default; see PEP 409
+            raise AttributeError(name) from None

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -168,6 +168,25 @@ The following public attributes are available of :class:`Task` instances:
 
    A boolean flag that indicates whether or not the task has run to completion.
 
+Task local storage
+------------------
+
+Curio supports "task local storage". The API is modeled after the
+"thread local storage" provided by :py:class:`threading.local`.
+
+.. class:: Local
+
+   A class representing a bundle of task-local values. Objects of this
+   class have no particular attributes or methods. Instead, they serve
+   as a blank slate to which you can add whatever attributes you
+   like. Modifications made from within one task will only be visible
+   to that task -- with one exception: when you create a new task
+   using ``curio.spawn``, then any values assigned to
+   :py:class:`Local` objects in the parent task will be inherited by
+   the child. This inheritance takes the form of a shallow copy --
+   further changes in the parent won't affect the child, and further
+   changes in the child won't affect the parent.
+
 Timeouts
 --------
 Any blocking operation in curio can be cancelled after a timeout.  The following

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,104 @@
+# test_tls.py
+
+import pytest
+from curio import *
+
+# Like run, but unwraps exceptions so pytest can see them properly.
+# Lets us use assert from inside async functions.
+def run_with_real_exceptions(*args, **kwargs):
+    try:
+        return run(*args, **kwargs)
+    except TaskError as e:
+        real = e.__cause__
+        # we can't avoid ending up with real.__context__ == e
+        # and if e.__cause__ = real then we end up with a reference loop that
+        # makes py.test blow up. So we have to None-out e.__cause__. (del is
+        # illegal.)
+        e.__cause__ = None
+        raise real from None
+
+def test_smoketest():
+    local = Local()
+
+    async def smoketest():
+        local.a = 1
+        assert local.a == 1
+        del local.a
+        with pytest.raises(AttributeError):
+            local.a
+        with pytest.raises(AttributeError):
+            del local.a
+
+    run_with_real_exceptions(smoketest())
+
+def test_isolation():
+    local = Local()
+
+    event1 = Event()
+    event2 = Event()
+    async def check_isolated_1():
+        local.a = 1
+        await event1.set()
+        await event2.wait()
+        assert local.a == 1
+
+    async def check_isolated_2():
+        await event1.wait()
+        # another task has done local.a = 1, but we shouldn't be able to see
+        # it
+        assert not hasattr(local, "a")
+        # Just like our assignment shouldn't be visible to them
+        local.a = 2
+        await event2.set()
+
+    async def check_isolated():
+        for task in [await spawn(check_isolated_1()),
+                     await spawn(check_isolated_2())]:
+            await task.join()
+
+    run_with_real_exceptions(check_isolated())
+
+def test_inheritance():
+    local = Local()
+
+    event1 = Event()
+    event2 = Event()
+    async def parent():
+        local.a = "both"
+        assert local.a == "both"
+        child_task = await spawn(child())
+        # now let the child check that it got the value, and try to change it
+        await event1.wait()
+        # child modification shouldn't be visible here
+        assert local.a == "both"
+        # and now check that the child can't see our change
+        local.a = "parent"
+        await event2.set()
+        await child_task.join()
+
+    async def child():
+        assert local.a == "both"
+        local.a = "child"
+        assert local.a == "child"
+        await event1.set()
+        await event2.wait()
+        assert local.a == "child"
+
+    run_with_real_exceptions(parent())
+
+def test_nested_curio():
+    # You should never do this. But that doesn't mean it should crash.
+
+    local = Local()
+
+    async def inner():
+        assert not hasattr(local, "a")
+        local.a = "inner"
+        assert local.a == "inner"
+
+    async def outer():
+        local.a = "outer"
+        run_with_real_exceptions(inner())
+        assert local.a == "outer"
+
+    run_with_real_exceptions(outer())


### PR DESCRIPTION
Implement task-local storage for curio.

No tests yet, but everything else is there.

I added a nice example of the API in action to the tutorial -- probably that's the thing to look at first.

# Open questions

To highlight the two API decisions that are most likely to be controversial / I'm most uncertain about:

## Sync vs async

I made the interface totally usable from synchronous code. Aside from being weird, this does force certain decisions in the implementation -- in particular it requires some hoop-jumping to set up and maintain a global (thread-local) rendesvous point for locating the current task metadata. This might have performance implications -- I haven't run benchmarks. (Specifically, doing it this way means there's a bit of extra overhead at every task switch; on the other hand, I suspect but haven't checked that it makes accessing TLS values faster than it would be if we had to trap every time.)

The rationale for this decision is that a major, probably *the* major use case for TLS in curio is for storing contextual metadata for logging. And logging is a thing where you kind of need to make it work, even under adverse conditions. Like if you're trying to siphon out data from stdlib `logging` and into a better system, then you should do that and probably rewriting every third-party library to stop using stdlib `logging` is not a viable option -- but stdlib `logging` is sync-land, so if we made this an async API we'd be stuck. Also you probably don't want to ever find yourself in the situation where you want to stick some debug statement in some random leaf function somewhere to figure out why everything is on fire... but oops that leaf function is synchronous, so you can't write `await log.debug(...)` without first refactoring a whole call chain.

## Inheritance

I made it so that child tasks inherit the initial values of TLS data from their parents (as a simple one-time shallow snapshot). This is very unusual among TLS implementations, but for a system like curio where tasks are small, cheap, and common, then I think it makes a lot of sense. Other alternatives include: (1) not inheriting, (2) fancier inheritance, like having children keep a pointer to their parent and if a key isn't found in a child traverse the graph looking for it (so changes in parents propagate to children but not vice-versa).

This does add some overhead to task spawning, though I suspect that it's *very* small in the common case (though it scales with the number of TLS keys in use).