### PR TITLE
Implement reentrant lock

### DIFF
--- a/curio/sync.py
+++ b/curio/sync.py
@@ -135,6 +135,7 @@ class RLock(_LockBase):
         me = await current_task()
 
         if self._owner is not me:
+
             await self._lock.acquire()
             self._owner = me
         self._count += 1
@@ -163,6 +164,8 @@ class RLock(_LockBase):
         """
         if not await current_task() is self._owner:
             raise RuntimeError('RLock can only be released by the owner')
+        if not self.locked():
+            raise RuntimeError('RLock is not locked')
         self._count -= 1
         if self._count == 0:
             await self._lock.release()

--- a/curio/sync.py
+++ b/curio/sync.py
@@ -4,7 +4,7 @@
 # events, locks, semaphores, and condition variables. These primitives
 # are only safe to use in the curio framework--they are not thread safe.
 
-__all__ = ['Event', 'Lock', 'Semaphore', 'BoundedSemaphore', 'Condition', 'abide' ]
+__all__ = ['Event', 'Lock', 'RLock', 'Semaphore', 'BoundedSemaphore', 'Condition', 'abide' ]
 
 import threading
 from inspect import iscoroutinefunction
@@ -12,8 +12,8 @@ from inspect import iscoroutinefunction
 from .traps import _wait_on_queue, _reschedule_tasks, _future_wait, _queue_reschedule_function
 from .kernel import kqueue
 from . import workers
-from .errors import CancelledError
-from .task import spawn
+from .errors import CancelledError, TaskTimeout
+from .task import spawn, current_task
 from .meta import awaitable
 
 class Event(object):
@@ -119,6 +119,37 @@ class Lock(_LockBase):
 
     def locked(self):
         return self._acquired
+
+
+class RLock(_LockBase):
+
+    __slots__ = ('_lock', '_owner', '_count')
+
+    def __init__(self):
+        self._lock = Lock()
+        self._owner = None
+        self._count = 0
+
+    async def acquire(self):
+        
+        me = await current_task()
+
+        if self._owner is not me:
+            await self._lock.acquire()
+            self._owner = me
+        self._count += 1
+        return True
+
+    async def release(self):
+        if not await current_task() is self._owner:
+            raise RuntimeError('RLock can only be released by the owner')
+        self._count -= 1
+        if self._count == 0:
+            await self._lock.release()
+
+    def locked(self):
+        return self._count > 0
+
 
 class Semaphore(_LockBase):
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -908,6 +908,30 @@ The preferred way to use a Lock is as an asynchronous context manager. For examp
 
     curio.run(main())
 
+.. class:: RLock()
+
+   This class provides a recursive lock funtionality, that could be acquired multiple times
+   within the same task. The behavior of this lock is identical to the ``threading.RLock``,
+   except that the owner of the lock will be a task, wich acquired it, instead of a thread.
+
+
+:class:`RLock` instances support the following methods:
+
+.. asyncmethod:: Lock.acquire()
+
+   Acquire the lock, incrementing the recursion by 1. Can be used multiple times withing 
+   the same task, that owns this lock.
+
+.. asyncmethod:: Lock.release()
+
+   Release the lock, decrementing the rerecurtion level by 1. If recursion level reaches 0,
+   the lock is unlocked. Can only be called by the owner task.
+
+.. method:: Lock.locked()
+
+   Return ``True`` if the lock is currently held, i.e. recursion level is greater than 0.
+
+
 .. class:: Semaphore(value=1)
 
    Create a semaphore.  Semaphores are based on a counter.  If the count is greater

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -925,7 +925,8 @@ The preferred way to use a Lock is as an asynchronous context manager. For examp
 .. asyncmethod:: Lock.release()
 
    Release the lock, decrementing the rerecurtion level by 1. If recursion level reaches 0,
-   the lock is unlocked. Can only be called by the owner task.
+   the lock is unlocked. Raises ``RuntimeError`` if called not by the owner or if lock
+   is not locked.
 
 .. method:: Lock.locked()
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -352,7 +352,6 @@ class TestRLock:
             await spawn(worker_simple(lck))
 
         kernel.run(main())
-        print(results)
         assert results == [
             False,
             'work1 wait',


### PR DESCRIPTION
This PR introduced the RLock implementation, similar to the `threading.RLock`.
This enables curio to allow users to re-acquire the lock if it is own by the 
same `curio.Task` instance. Here is an example use case:

``` python
import curio

async def coro(lck):
    async with lock:
        print('Critical section')

async def parent_coro(lck):
    async with lock:
        await coro()

async def main():
    await curio.spawn(parent_coro(curio.RLock()))

if __name__ == '__main__':
    curio.run(man())
```

If the above code was using a simple `curio.Lock`, it would end up in a deadlock, while with
a reentrant lock it works just fine.
