### PR TITLE
Rename task-local storage -> context-local storage

### DIFF
--- a/curio/__init__.py
+++ b/curio/__init__.py
@@ -11,7 +11,7 @@ from .queue import *
 from .workers import *
 from .network import *
 from .file import *
-from .tls import *
+from .cls import *
 
 __all__ = [ *errors.__all__,
             *task.__all__,
@@ -22,5 +22,5 @@ __all__ = [ *errors.__all__,
             *workers.__all__,
             *network.__all__,
             *file.__all__,
-            *tls.__all__,
+            *cls.__all__,
            ]

--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -19,7 +19,7 @@ from .errors import *
 from .errors import _CancelRetry
 from .task import Task
 from .traps import _read_wait, Traps
-from .tls import _enable_tls_for, _copy_tls
+from .cls import _enable_cls_for, _copy_cls
 
 # kqueue is the datatype used by the kernel for all of its queuing functionality.
 # Any time a task queue is needed, use this type instead of directly hard-coding the
@@ -416,7 +416,7 @@ class Kernel(object):
         # Add a new task to the kernel
         def _trap_spawn(_, coro, daemon):
             task = _new_task(coro, daemon)
-            _copy_tls(current, task)
+            _copy_cls(current, task)
             _reschedule_task(current, value=task)
 
         # Reschedule one or more tasks from a queue
@@ -627,7 +627,7 @@ class Kernel(object):
                 try:
                     current.state = 'RUNNING'
                     current.cycles += 1
-                    with _enable_tls_for(current):
+                    with _enable_cls_for(current):
                         if current.next_exc is None:
                             trap = current._send(current.next_value)
                         else:

--- a/curio/task.py
+++ b/curio/task.py
@@ -18,7 +18,7 @@ class Task(object):
         'id', 'daemon', 'coro', '_send', '_throw', 'cycles', 'state',
         'cancel_func', 'future', 'sleep', 'timeout', 'exc_info', 'next_value',
         'next_exc', 'joining', 'cancelled', 'terminated', '_last_io', '_deadlines',
-        'task_local_storage', '__weakref__',
+        'context_local_storage', '__weakref__',
         )
     _lastid = 1
 
@@ -41,7 +41,7 @@ class Task(object):
         self.joining = None        # Optional set of tasks waiting to join with this one
         self.cancelled = False     # Cancelled?
         self.terminated = False    # Terminated?
-        self.task_local_storage = {} # Task local storage
+        self.context_local_storage = {} # Context local storage
         self._last_io = None       # Last I/O operation performed
         self._send = coro.send     # Bound coroutine methods
         self._throw = coro.throw

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -168,17 +168,17 @@ The following public attributes are available of :class:`Task` instances:
 
    A boolean flag that indicates whether or not the task has run to completion.
 
-Task local storage
-------------------
+Context local storage
+---------------------
 
-Curio supports "task local storage". The API is modeled after the
+Curio supports "context local storage". The API is modeled after the
 "thread local storage" provided by :py:class:`threading.local`.
 
 .. class:: Local
 
-   A class representing a bundle of task-local values. Objects of this
-   class have no particular attributes or methods. Instead, they serve
-   as a blank slate to which you can add whatever attributes you
+   A class representing a bundle of context-local values. Objects of
+   this class have no particular attributes or methods. Instead, they
+   serve as a blank slate to which you can add whatever attributes you
    like. Modifications made from within one task will only be visible
    to that task -- with one exception: when you create a new task
    using ``curio.spawn``, then any values assigned to

--- a/tests/test_cls.py
+++ b/tests/test_cls.py
@@ -1,4 +1,4 @@
-# test_tls.py
+# test_cls.py
 
 import pytest
 from curio import *


### PR DESCRIPTION
To avoid confusion with Transport Layer Security and Thread-Local
Storage.