### PR TITLE
Add curio.defer_cancellation and Task.cancel_no_wait

### DIFF
--- a/curio/traps.py
+++ b/curio/traps.py
@@ -12,9 +12,9 @@
 
 __all__ = [
     '_read_wait', '_write_wait', '_future_wait', '_sleep', '_spawn',
-    '_cancel_task', '_join_task', '_wait_on_queue',
-    '_reschedule_tasks', '_queue_reschedule_function', '_sigwatch',
-    '_sigunwatch', '_sigwait', '_get_kernel', '_get_current',
+    '_cancel_task', '_adjust_cancel_defer_depth', '_join_task',
+    '_wait_on_queue', '_reschedule_tasks', '_queue_reschedule_function',
+    '_sigwatch', '_sigunwatch', '_sigwait', '_get_kernel', '_get_current',
     '_set_timeout', '_unset_timeout', '_clock',
     ]
 
@@ -42,6 +42,7 @@ class Traps(IntEnum):
     _trap_unset_timeout = 14
     _trap_queue_reschedule_function = 15
     _trap_clock = 16
+    _trap_adjust_cancel_defer_depth = 17
 
 globals().update((key,val) for key, val in vars(Traps).items() if key.startswith('_trap'))
 
@@ -95,6 +96,14 @@ def _cancel_task(task):
             return
         except _CancelRetry:
             pass
+
+@coroutine
+def _adjust_cancel_defer_depth(n):
+    '''
+    Increment or decrement the current task's cancel_defer_depth. If it goes
+    to 0, and the task was previously cancelled, then raises CancelledError.
+    '''
+    yield (_trap_adjust_cancel_defer_depth, n)
 
 @coroutine
 def _join_task(task):


### PR DESCRIPTION
curio.defer_cancellation is an async context manager which defers any
cancellations until after leaving the 'async with' block. See
gh-96.

It *should* also defer timeout exceptions, but it doesn't yet.

cancel_no_wait is like cancel, but it doesn't wait for the task to
exit. I needed it to write a test for defer_cancellation, and was just
wanting it anyway for some user code I was working on...

I'm not sure whether it makes sense to have both cancel() and
cancel_no_wait() -- maybe cancel_no_wait() should be renamed to just
become cancel()? But for now I left both in.