### PR TITLE
Sync traps

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -495,7 +495,7 @@ class Kernel(object):
                 _reschedule_task(current, value=time_monotonic())
 
         # Watch signals
-        def _trap_sigwatch(sigset):
+        def _sync_trap_sigwatch(sigset):
             # Initialize the signal handling part of the kernel if not done already
             # Note: This only works if running in the main thread
             if self._kernel_task_id is None:
@@ -505,12 +505,10 @@ class Kernel(object):
                 self._init_signals()
 
             self._signal_watch(sigset)
-            _reschedule_task(current)
 
         # Unwatch signals
-        def _trap_sigunwatch(sigset):
+        def _sync_trap_sigunwatch(sigset):
             self._signal_unwatch(sigset)
-            _reschedule_task(current)
 
         # Wait for a signal
         def _trap_sigwait(sigset):

--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -422,17 +422,15 @@ class Kernel(object):
 
         # Reschedule one or more tasks from a queue
         def _trap_reschedule_tasks(queue, n):
-            while n > 0:
+            for _ in range(n):
                 _reschedule_task(queue.popleft())
-                n -= 1
             _reschedule_task(current)
 
         # Trap that returns a function for rescheduling tasks from synchronous code
         def _sync_trap_queue_reschedule_function(queue):
             def _reschedule(n):
-                while n > 0:
+                for _ in range(n):
                     _reschedule_task(queue.popleft())
-                    n -= 1
             return _reschedule
 
         # Join with a task
@@ -444,7 +442,7 @@ class Kernel(object):
                     task.joining = kqueue()
                 _trap_wait_queue(task.joining, 'TASK_JOIN')
 
-        # Enter or exit a 'with curio.defer_cancellation' block:
+        # Enter or exit an 'async with curio.defer_cancellation' block:
         def _sync_trap_adjust_cancel_defer_depth(n):
             current.cancel_defer_depth += n
             if current.cancel_defer_depth == 0 and current.cancel_pending:
@@ -462,7 +460,6 @@ class Kernel(object):
             if task.cancelled:
                 ready_appendleft(current)
             elif task.cancel_defer_depth > 0:
-                print("Deferred")
                 task.cancel_pending = True
                 ready_appendleft(current)
             elif _cancel_task(task, CancelledError):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -42,10 +42,9 @@ class Traps(IntEnum):
     _trap_unset_timeout = 14
     _trap_queue_reschedule_function = 15
     _trap_clock = 16
-    _trap_adjust_cancel_defer_depth = 17
 
 class SyncTraps(IntEnum):
-    pass
+    _sync_trap_adjust_cancel_defer_depth = 0
 
 globals().update((trap.name, trap) for trap in Traps)
 globals().update((trap.name, trap) for trap in SyncTraps)
@@ -107,7 +106,7 @@ def _adjust_cancel_defer_depth(n):
     Increment or decrement the current task's cancel_defer_depth. If it goes
     to 0, and the task was previously cancelled, then raises CancelledError.
     '''
-    yield (_trap_adjust_cancel_defer_depth, n)
+    yield (_sync_trap_adjust_cancel_defer_depth, n)
 
 @coroutine
 def _join_task(task):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -33,9 +33,7 @@ class Traps(IntEnum):
     _trap_join_task = 5
     _trap_wait_queue = 6
     _trap_reschedule_tasks = 7
-    _trap_sigwatch = 8
-    _trap_sigunwatch = 9
-    _trap_sigwait = 10
+    _trap_sigwait = 8
 
 class SyncTraps(IntEnum):
     _sync_trap_adjust_cancel_defer_depth = 0
@@ -45,6 +43,8 @@ class SyncTraps(IntEnum):
     _sync_trap_unset_timeout = 4
     _sync_trap_queue_reschedule_function = 5
     _sync_trap_clock = 6
+    _sync_trap_sigwatch = 7
+    _sync_trap_sigunwatch = 8
 
 globals().update((trap.name, trap) for trap in Traps)
 globals().update((trap.name, trap) for trap in SyncTraps)
@@ -134,14 +134,14 @@ def _sigwatch(sigset):
     '''
     Start monitoring a signal set
     '''
-    yield (_trap_sigwatch, sigset)
+    yield (_sync_trap_sigwatch, sigset)
 
 @coroutine
 def _sigunwatch(sigset):
     '''
     Stop watching a signal set
     '''
-    yield (_trap_sigunwatch, sigset)
+    yield (_sync_trap_sigunwatch, sigset)
 
 @coroutine
 def _sigwait(sigset):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -44,7 +44,11 @@ class Traps(IntEnum):
     _trap_clock = 16
     _trap_adjust_cancel_defer_depth = 17
 
-globals().update((key,val) for key, val in vars(Traps).items() if key.startswith('_trap'))
+class SyncTraps(IntEnum):
+    pass
+
+globals().update((trap.name, trap) for trap in Traps)
+globals().update((trap.name, trap) for trap in SyncTraps)
 
 @coroutine
 def _read_wait(fileobj):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -36,15 +36,15 @@ class Traps(IntEnum):
     _trap_sigwatch = 8
     _trap_sigunwatch = 9
     _trap_sigwait = 10
-    _trap_get_kernel = 11
-    _trap_get_current = 12
-    _trap_set_timeout = 13
-    _trap_unset_timeout = 14
-    _trap_queue_reschedule_function = 15
-    _trap_clock = 16
 
 class SyncTraps(IntEnum):
     _sync_trap_adjust_cancel_defer_depth = 0
+    _sync_trap_get_kernel = 1
+    _sync_trap_get_current = 2
+    _sync_trap_set_timeout = 3
+    _sync_trap_unset_timeout = 4
+    _sync_trap_queue_reschedule_function = 5
+    _sync_trap_clock = 6
 
 globals().update((trap.name, trap) for trap in Traps)
 globals().update((trap.name, trap) for trap in SyncTraps)
@@ -155,14 +155,14 @@ def _get_kernel():
     '''
     Get the kernel executing the task.
     '''
-    return (yield (_trap_get_kernel,))
+    return (yield (_sync_trap_get_kernel,))
 
 @coroutine
 def _get_current():
     '''
     Get the currently executing task
     '''
-    return (yield (_trap_get_current,))
+    return (yield (_sync_trap_get_current,))
 
 @coroutine
 def _set_timeout(clock):
@@ -170,14 +170,14 @@ def _set_timeout(clock):
     Set a timeout for the current task that occurs at the specified clock value.
     Setting a clock of None clears any previous timeout. 
     '''
-    return (yield (_trap_set_timeout, clock))
+    return (yield (_sync_trap_set_timeout, clock))
 
 @coroutine
 def _unset_timeout(previous):
     '''
     Restore the previous timeout for the current task.
     '''
-    yield (_trap_unset_timeout, previous)
+    yield (_sync_trap_unset_timeout, previous)
 
 @coroutine
 def _queue_reschedule_function(queue):
@@ -186,11 +186,11 @@ def _queue_reschedule_function(queue):
     the use of await.   Can be used in synchronous code as long as it runs
     in the same thread as the Curio kernel.
     '''
-    return (yield (_trap_queue_reschedule_function, queue))
+    return (yield (_sync_trap_queue_reschedule_function, queue))
 
 @coroutine
 def _clock():
     '''
     Return the value of the kernel clock
     '''
-    return (yield (_trap_clock,))
+    return (yield (_sync_trap_clock,))

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1582,11 +1582,13 @@ timed-out.
 
 .. asyncfunction:: _sigwatch(sigset)
 
-   Tell the kernel to start queuing signals in the given signal set *sigset*.
+   Synchronous trap. Tell the kernel to start queuing signals in the
+   given signal set *sigset*.
 
 .. asyncfunction:: _sigunwatch(sigset)
 
-   Tell the kernel to stop queuing signals in the given signal set.
+   Synchronous trap. Tell the kernel to stop queuing signals in the
+   given signal set.
 
 .. asyncfunction:: _sigwait(sigset)
 


### PR DESCRIPTION
Refactor trap internals to formalize the distinction between regular and "synchronous" traps. See #101 for motivation. Also convert the "obvious" traps to make them sync traps.

Specifically, the following traps are made sync:
* `adjust_cancel_defer_depth`
* `get_kernel`
* `get_current`
* `set_timeout`
* `unset_timeout`
* `queue_reschedule_function`
* `clock`
* `sigwatch`
* `sigunwatch`

The following traps in principle *could* be made sync, but either there's some complication or it isn't obvious whether those are actually the semantics we want, so I left them alone for now:
* `cancel_task`
* `spawn`
* `reschedule_tasks`

When switching traps to make them synchronous I also renamed them. This isn't at all mandatory, but since the name of the trap = the name of the trap handler function, and sync trap handlers have a different calling convention than regular trap handlers, I thought it was helpful to have that reminder in the name of which kind of handler we're implementing.

This also contains some small cleanups to regular trap handling and adds some missing docs.
