### PR TITLE
Improve the monitor CLI and internals

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -66,9 +66,11 @@ class Kernel(object):
         self._pdb = pdb
         self._log_errors = log_errors
 
+        self._monitor = None
+
         # If a monitor is specified, launch it
         if with_monitor or 'CURIOMONITOR' in os.environ:
-            Monitor(self)
+            self._monitor = Monitor(self)
 
     def __del__(self):
         if self._selector is not None:
@@ -79,6 +81,8 @@ class Kernel(object):
 
     def __exit__(self, *args):
         self.run(shutdown=True)
+        if self._monitor:
+            self._monitor.close()
 
     # Force the kernel to wake, possibly scheduling a task to run.
     # This method is called by threads running concurrently to the

--- a/curio/monitor.py
+++ b/curio/monitor.py
@@ -22,7 +22,7 @@
 # Where host and port configure the network address on which the monitor
 # operates.
 #
-# To connect to the monitor, run python3 -m curio.monitor [port]. For example:
+# To connect to the monitor, run python3 -m curio.monitor -H [host] -p [port]. For example:
 #
 # Theory of operation:
 # --------------------
@@ -57,6 +57,7 @@ import socket
 import threading
 import queue
 import telnetlib
+import argparse
 import logging
 
 # --- Curio
@@ -249,9 +250,19 @@ def monitor_client(host, port):
     tn.interact()
     tn.close()
 
+
+def main():
+    parser = argparse.ArgumentParser("usage: python -m curio.monitor [options]")
+    parser.add_argument("-H", "--host", dest="monitor_host",
+                        default=MONITOR_HOST, type=str,
+                        help="monitor host ip")
+
+    parser.add_argument("-p", "--port", dest="monitor_port",
+                        default=MONITOR_PORT, type=int,
+                        help="monitor port number")
+    args = parser.parse_args()
+    monitor_client(args.monitor_host, args.monitor_port)
+
+
 if __name__ == '__main__':
-    if sys.argv[1:]:
-        port = int(sys.argv[1])
-    else:
-        port = MONITOR_PORT
-    monitor_client(MONITOR_HOST, port)
+    main()

--- a/curio/monitor.py
+++ b/curio/monitor.py
@@ -105,6 +105,7 @@ def _format_stack(task):
         resp += ''.join(traceback.format_list(extracted_list))
     return resp
 
+
 class Monitor(object):
     '''
     Task monitor that runs concurrently to the curio kernel in a
@@ -119,10 +120,17 @@ class Monitor(object):
 
         # The monitor launches both a separate thread and helper task
         # that runs inside curio itself to manage cancellation events
-        threading.Thread(target=self.server, daemon=True).start()
+        self._ui_thread = threading.Thread(target=self.server, args=(), daemon=True)
+        self._closing = threading.Event()
+        self._ui_thread.start()
+
         monitor_task = Task(self.monitor_task(), daemon=True)
         kern._ready.append(monitor_task)
         kern._tasks[monitor_task.id] = monitor_task
+
+    def close(self):
+        self._closing.set()
+        self._ui_thread.join()
 
     async def monitor_task(self):
         '''
@@ -139,15 +147,27 @@ class Monitor(object):
         from curio itself.
         '''
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except AttributeError:
+            pass
+
+        # set the timeout to prevent the server loop from
+        # blocking indefinitaly on sock.accept()
+        sock.settimeout(0.5)
         sock.bind(self.address)
         sock.listen(1)
-        while True:
-            client, addr = sock.accept()
-            sout = client.makefile('w', encoding='utf-8')
-            sin = client.makefile('r', encoding='utf-8')
-            self.interactive_loop(sout, sin)
-            client.close()
+        with sock:
+            while not self._closing.is_set():
+                try:
+                    client, addr = sock.accept()
+                    with client:
+                        sout = client.makefile('w', encoding='utf-8')
+                        sin = client.makefile('r', encoding='utf-8')
+                        self.interactive_loop(sout, sin)
+                except socket.timeout:
+                    continue
 
     def interactive_loop(self, sout, sin):
         '''
@@ -155,7 +175,7 @@ class Monitor(object):
         '''
         sout.write('\nCurio Monitor: %d tasks running\n' % len(self.kernel._tasks))
         sout.write('Type help for commands\n')
-        while True:
+        while not self._closing.is_set():
             sout.write('curio > ')
             sout.flush()
             resp = sin.readline()


### PR DESCRIPTION
In this PR:

- enhanced the CLI for curio.monitor using `argparse`
- properly terminate the monitor thread when exiting from the kernel