### PR TITLE
Implement zero cost task switch

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -530,6 +530,9 @@ class Kernel(object):
             current.state = 'TIME_SLEEP'
             current.cancel_func = lambda task=current: setattr(task, 'sleep', None)
 
+        def _trap_switch():
+            _reschedule_task(current)
+
         # Watch signals
         def _sync_trap_sigwatch(sigset):
             # Initialize the signal handling part of the kernel if not done already

--- a/curio/task.py
+++ b/curio/task.py
@@ -110,7 +110,7 @@ async def current_task():
 
 async def switch():
     """
-    Switch to the next ready task.
+    Switch to the next ready task
 
     Usage:
 

--- a/curio/task.py
+++ b/curio/task.py
@@ -2,7 +2,7 @@
 #
 # Task class and task related functions.
 
-__all__ = [ 'Task', 'sleep', 'wake_at', 'current_task', 'spawn', 'gather', 
+__all__ = [ 'Task', 'sleep', 'wake_at', 'current_task', 'switch', 'spawn', 'gather', 
             'timeout_after', 'timeout_at', 'ignore_after', 'ignore_at',
             'wait', 'clock' , 'defer_cancellation']
 
@@ -107,6 +107,24 @@ async def current_task():
     Returns a reference to the current task
     '''
     return await _get_current()
+
+async def switch():
+    """
+    Switch to the next ready task.
+
+    Usage:
+
+         await switch()
+
+    The end result is identical to
+
+         await curio.sleep(0)
+
+    except that it bypasses all the time scheduling routine,
+    which should make it faster.
+
+    """
+    return await _switch()
 
 async def sleep(seconds):
     '''

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -15,7 +15,7 @@ __all__ = [
     '_cancel_task', '_adjust_cancel_defer_depth', '_join_task',
     '_wait_on_queue', '_reschedule_tasks', '_queue_reschedule_function',
     '_sigwatch', '_sigunwatch', '_sigwait', '_get_kernel', '_get_current',
-    '_set_timeout', '_unset_timeout', '_clock', 
+    '_switch', '_set_timeout', '_unset_timeout', '_clock', 
     ]
 
 from types import coroutine
@@ -34,6 +34,7 @@ class Traps(IntEnum):
     _trap_wait_queue = 6
     _trap_reschedule_tasks = 7
     _trap_sigwait = 8
+    _trap_switch = 9
 
 class SyncTraps(IntEnum):
     _sync_trap_adjust_cancel_defer_depth = 0
@@ -79,6 +80,10 @@ def _sleep(clock, absolute):
     period is an absolute time or relative.
     '''
     return (yield (_trap_sleep, clock, absolute))
+
+@coroutine
+def _switch():
+    return (yield (_trap_switch, ))
 
 @coroutine
 def _spawn(coro, daemon):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -83,6 +83,7 @@ def _sleep(clock, absolute):
 
 @coroutine
 def _switch():
+    """Switch to the next ready task"""
     return (yield (_trap_switch, ))
 
 @coroutine

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -94,6 +94,12 @@ The following functions are defined to help manage the execution of tasks.
    value of the monotonic clock at the time the task awakes.  Use this function
    if you need to have more precise interval timing.
 
+.. asyncfunction:: switch(clock)
+
+   Voluntarily switch to the next task. This is a convenience utility so users
+   do not need to use :func:`sleep` with a 0 time offset. It also faster than
+   sleeping for 0 seconds due to the curio's internals.
+
 .. asyncfunction:: current_task()
 
    Returns a reference to the :class:`Task` instance corresponding to the

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -795,3 +795,31 @@ def test_sleep_0_starvation(kernel):
         await loop_task.cancel()
 
     kernel.run(main())
+
+
+def test_switch(kernel):
+
+    results = []
+
+    async def swither():
+        results.append('switcher running')
+        await switch()
+        results.append('switcher continues')
+
+    async def main():
+        await spawn(swither())
+        results.append('switcher waiting')
+        await sleep(0)
+        results.append('all done')
+
+        print(results)
+
+    kernel.run(main())
+
+    assert results == [
+        'switcher running',
+        'switcher waiting',
+        'switcher continues',
+        'all done'
+    ]
+


### PR DESCRIPTION
This PR introduces the new switch utility. This should be more convenient to use, that `await sleep(0)`, makes API more semantically correct and also should be faster.