### PR TITLE
Pluggable scheduler queue proof-of-concept

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -34,12 +34,16 @@ kqueue = deque
 
 class Kernel(object):
     def __init__(self, *, selector=None, with_monitor=False, pdb=False, log_errors=True,
+                 scheduler_queue=None,
                  crash_handler=None):
         if selector is None:
             selector = DefaultSelector()
 
+        if scheduler_queue is None:
+            scheduler_queue = kqueue
+
         self._selector = selector
-        self._ready = kqueue()            # Tasks ready to run
+        self._ready = scheduler_queue()            # Tasks ready to run
         self._tasks = { }                 # Task table
         # Dict { signo: [ sigsets ] } of watched signals (initialized only if signals used)
         self._signal_sets = None
@@ -147,7 +151,7 @@ class Kernel(object):
         if self._thread_pool:
             self._thread_pool.shutdown()
             self._thread_pool = None
-        
+
         if self._process_pool:
             self._process_pool.shutdown()
             self._process_pool = None


### PR DESCRIPTION
In this PR I propose a simple change to allow a pluggable task scheduler queue. I chose to add an argument to the kernel constructor instead of patching a global variable. Since other components of curio, like locks, semaphores etc, that utilize `kqueue`, do not need a particularly sophisticated internal queues to maintain waiters, this change will only impact a kernel scheduling. 

Feedback appreciated