### PR TITLE
Unconditionally poll for I/O

### DIFF
--- a/examples/bench/curioecho.py
+++ b/examples/bench/curioecho.py
@@ -7,7 +7,7 @@ async def echo_handler(client, addr):
     print('Connection from', addr)
     client.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
     while True:
-        data = await client.recv(1000000)
+        data = await client.recv(10000)
         if not data:
             break
         await client.sendall(data)


### PR DESCRIPTION
This PR forces even loop to poll for I/O unconditionally, even if there are tasks ready to run. This is done mitigate risks of starvation, so it makes the event loop more reliable (see #112), and also gives an opportunity to safely reschedule tasks. Performance of the event loop is not affected at all.