### PR TITLE
[rfc] Finish splitting traps into blocking vs. synchronous

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -398,9 +398,21 @@ class Kernel(object):
         # and there is no public API outside the kernel.  Instead,
         # coroutines use a statement such as
         #
-        #   yield ('_trap_io', sock, EVENT_READ, 'READ_WAIT')
+        #   yield (_blocking_trap_io, sock, EVENT_READ, 'READ_WAIT')
         #
         # to invoke a specific trap.
+        #
+        # There are two calling conventions we use for implementing these:
+        #
+        # 1) Blocking trap handlers return the new values for
+        #
+        #       (task.state, task.cancel_func)
+        #
+        #    They don't have any way to pass values/exceptions back to the
+        #    invoker.
+        #
+        # 2) Sync trap handlers act like regular function calls -- whatever
+        #    they return or raise will be passed back to the invoker.
 
         # Wait for I/O
         def _blocking_trap_io(fileobj, event, state):

--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -454,16 +454,15 @@ class Kernel(object):
                 event.set()
 
         # Add a new task to the kernel
-        def _trap_spawn(coro, daemon):
+        def _sync_trap_spawn(coro, daemon):
             task = _new_task(coro, daemon)
             _copy_tasklocal(current, task)
-            _reschedule_task(current, value=task)
+            return task
 
         # Reschedule one or more tasks from a queue
-        def _trap_reschedule_tasks(queue, n):
+        def _sync_trap_reschedule_tasks(queue, n):
             for _ in range(n):
                 _reschedule_task(queue.popleft())
-            _reschedule_task(current)
 
         # Trap that returns a function for rescheduling tasks from synchronous code
         def _sync_trap_queue_reschedule_function(queue):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -24,13 +24,13 @@ from enum import IntEnum
 
 from .errors import _CancelRetry
 
-class Traps(IntEnum):
-    _trap_io = 0
-    _trap_future_wait = 1
-    _trap_sleep = 2
-    _trap_join_task = 3
-    _trap_wait_queue = 4
-    _trap_sigwait = 5
+class BlockingTraps(IntEnum):
+    _blocking_trap_io = 0
+    _blocking_trap_future_wait = 1
+    _blocking_trap_sleep = 2
+    _blocking_trap_join_task = 3
+    _blocking_trap_wait_queue = 4
+    _blocking_trap_sigwait = 5
 
 class SyncTraps(IntEnum):
     _sync_trap_adjust_cancel_defer_depth = 0
@@ -46,7 +46,7 @@ class SyncTraps(IntEnum):
     _sync_trap_reschedule_tasks = 10
     _sync_trap_cancel_task = 11
 
-globals().update((trap.name, trap) for trap in Traps)
+globals().update((trap.name, trap) for trap in BlockingTraps)
 globals().update((trap.name, trap) for trap in SyncTraps)
 
 @coroutine
@@ -54,21 +54,21 @@ def _read_wait(fileobj):
     '''
     Wait until reading can be performed.
     '''
-    yield (_trap_io, fileobj, EVENT_READ, 'READ_WAIT')
+    yield (_blocking_trap_io, fileobj, EVENT_READ, 'READ_WAIT')
 
 @coroutine
 def _write_wait(fileobj):
     '''
     Wait until writing can be performed.
     '''
-    yield (_trap_io, fileobj, EVENT_WRITE, 'WRITE_WAIT')
+    yield (_blocking_trap_io, fileobj, EVENT_WRITE, 'WRITE_WAIT')
 
 @coroutine
 def _future_wait(future, event=None):
     '''
     Wait for the result of a Future to be ready.
     '''
-    yield (_trap_future_wait, future, event)
+    yield (_blocking_trap_future_wait, future, event)
 
 @coroutine
 def _sleep(clock, absolute):
@@ -78,7 +78,7 @@ def _sleep(clock, absolute):
     absolute is a boolean flag that indicates whether or not the clock
     period is an absolute time or relative.
     '''
-    return (yield (_trap_sleep, clock, absolute))
+    return (yield (_blocking_trap_sleep, clock, absolute))
 
 @coroutine
 def _spawn(coro, daemon):
@@ -107,14 +107,14 @@ def _join_task(task):
     '''
     Wait for a task to terminate.
     '''
-    yield (_trap_join_task, task)
+    yield (_blocking_trap_join_task, task)
 
 @coroutine
 def _wait_on_queue(queue, state):
     '''
     Put the task to sleep on a queue.
     '''
-    yield (_trap_wait_queue, queue, state)
+    yield (_blocking_trap_wait_queue, queue, state)
 
 @coroutine
 def _reschedule_tasks(queue, n=1):
@@ -142,7 +142,7 @@ def _sigwait(sigset):
     '''
     Wait for a signal to arrive.
     '''
-    yield (_trap_sigwait, sigset)
+    yield (_blocking_trap_sigwait, sigset)
 
 @coroutine
 def _get_kernel():

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -28,12 +28,10 @@ class Traps(IntEnum):
     _trap_io = 0
     _trap_future_wait = 1
     _trap_sleep = 2
-    _trap_spawn = 3
-    _trap_cancel_task = 4
-    _trap_join_task = 5
-    _trap_wait_queue = 6
-    _trap_reschedule_tasks = 7
-    _trap_sigwait = 8
+    _trap_cancel_task = 3
+    _trap_join_task = 4
+    _trap_wait_queue = 5
+    _trap_sigwait = 6
 
 class SyncTraps(IntEnum):
     _sync_trap_adjust_cancel_defer_depth = 0
@@ -45,6 +43,8 @@ class SyncTraps(IntEnum):
     _sync_trap_clock = 6
     _sync_trap_sigwatch = 7
     _sync_trap_sigunwatch = 8
+    _sync_trap_spawn = 9
+    _sync_trap_reschedule_tasks = 10
 
 globals().update((trap.name, trap) for trap in Traps)
 globals().update((trap.name, trap) for trap in SyncTraps)
@@ -85,7 +85,7 @@ def _spawn(coro, daemon):
     '''
     Create a new task. Returns the resulting Task object.
     '''
-    return (yield _trap_spawn, coro, daemon)
+    return (yield _sync_trap_spawn, coro, daemon)
 
 @coroutine
 def _cancel_task(task):
@@ -127,7 +127,7 @@ def _reschedule_tasks(queue, n=1):
     '''
     Reschedule one or more tasks waiting on a kernel queue.
     '''
-    yield (_trap_reschedule_tasks, queue, n)
+    yield (_sync_trap_reschedule_tasks, queue, n)
 
 @coroutine
 def _sigwatch(sigset):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -28,10 +28,9 @@ class Traps(IntEnum):
     _trap_io = 0
     _trap_future_wait = 1
     _trap_sleep = 2
-    _trap_cancel_task = 3
-    _trap_join_task = 4
-    _trap_wait_queue = 5
-    _trap_sigwait = 6
+    _trap_join_task = 3
+    _trap_wait_queue = 4
+    _trap_sigwait = 5
 
 class SyncTraps(IntEnum):
     _sync_trap_adjust_cancel_defer_depth = 0
@@ -45,6 +44,7 @@ class SyncTraps(IntEnum):
     _sync_trap_sigunwatch = 8
     _sync_trap_spawn = 9
     _sync_trap_reschedule_tasks = 10
+    _sync_trap_cancel_task = 11
 
 globals().update((trap.name, trap) for trap in Traps)
 globals().update((trap.name, trap) for trap in SyncTraps)
@@ -91,14 +91,8 @@ def _spawn(coro, daemon):
 def _cancel_task(task):
     '''
     Cancel a task. Causes a CancelledError exception to raise in the task.
-    The exception can be changed by specifying exc.
     '''
-    while True:
-        try:
-            yield (_trap_cancel_task, task)
-            return
-        except _CancelRetry:
-            pass
+    yield (_sync_trap_cancel_task, task)
 
 @coroutine
 def _adjust_cancel_defer_depth(n):

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -117,18 +117,19 @@ that serves as a kind of wrapper around the underlying coroutine that's executin
    If called on a task that has been cancelled, the `__cause__`
    attribute is set to :exc:`curio.CancelledError`.
 
-.. asyncmethod:: Task.cancel()
+.. asyncmethod:: Task.cancel(blocking=True)
 
-   Cancels the task.  This raises a :exc:`curio.CancelledError` exception in
-   the task which may choose to handle it in order to perform cleanup
-   actions.  Does not return until the task actually terminates.
-   Curio only allows a task to be cancelled once.  If this method is
-   somehow invoked more than once on a still running task, the second
-   request will merely wait until the task is cancelled from the first
-   request.  If the task has already run to completion, this method
-   does nothing and returns immediately.  Returns ``True`` if the task
-   was actually cancelled. ``False`` is returned if the task was
-   already finished prior to the cancellation request.
+   Cancels the task. This raises a :exc:`curio.CancelledError`
+   exception in the task which may choose to handle it in order to
+   perform cleanup actions. If ``blocking=True`` (the default), does
+   not return until the task actually terminates.  Curio only allows a
+   task to be cancelled once. If this method is somehow invoked more
+   than once on a still running task, the second request will merely
+   wait until the task is cancelled from the first request.  If the
+   task has already run to completion, this method does nothing and
+   returns immediately.  Returns ``True`` if the task was actually
+   cancelled. ``False`` is returned if the task was already finished
+   prior to the cancellation request.
 
 The following public attributes are available of :class:`Task` instances:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1530,56 +1530,55 @@ yourself using these, you're probably doing something wrong--or
 implementing a new curio primitive.   These calls are found in the
 ``curio.traps`` submodule.
 
-Traps come in two flavors: *regular* and *synchronous*. A synchronous
-trap is implemented by trapping into the kernel, but semantically it
-acts like a regular synchronous function call. Specifically, this
-means that it always returns immediately without running any other
-task, and that it does not act as a cancellation point. Regular traps
-might or might not block or yield execution, and can be cancelled or
-timed-out.
+Traps come in two flavors: *blocking* and *synchronous*. A blocking
+trap might block for an indefinite period of time while allowing other
+tasks to run, and always checks for and raises any pending timeouts or
+cancellations. A synchronous trap is implemented by trapping into the
+kernel, but semantically it acts like a regular synchronous function
+call. Specifically, this means that it always returns immediately
+without running any other task, and that it does *not* act as a
+cancellation point.
 
 .. asyncfunction:: _read_wait(fileobj)
 
-   Sleep until data is available for reading on *fileobj*.  *fileobj* is
-   any file-like object with a `fileno()` method.
+   Blocking trap. Sleep until data is available for reading on
+   *fileobj*.  *fileobj* is any file-like object with a `fileno()`
+   method.
 
 .. asyncfunction:: _write_wait(fileobj)
 
-   Sleep until data can be written on *fileobj*.  *fileobj* is
-   any file-like object with a `fileno()` method.
+   Blocking trap. Sleep until data can be written on *fileobj*.
+   *fileobj* is any file-like object with a `fileno()` method.
 
 .. asyncfunction:: _future_wait(future)
 
-   Sleep until a result is set on *future*.  *future* is an instance of
-   :py:class:`concurrent.futures.Future`.
+   Blocking trap. Sleep until a result is set on *future*.  *future*
+   is an instance of :py:class:`concurrent.futures.Future`.
 
 .. asyncfunction:: _join_task(task)
 
-   Sleep until the indicated *task* completes.  The final return value
-   of the task is returned if it completed successfully. If the task
-   failed with an exception, a :exc:`curio.TaskError` exception is
-   raised.  This is a chained exception.  ``TaskError.__cause__``
-   attribute of this exception contains the actual exception raised in
-   the task.
+   Blocking trap. Sleep until the indicated *task* completes. After
+   this trap completes, then the task's return value or raised
+   exception information is available in ``task.next_value`` or
+   ``task.exc_info``, respectively.
 
 .. asyncfunction:: _cancel_task(task)
 
-   Cancel the indicated *task*.  Does not return until the task actually
-   completes the cancellation.  Note: It is usually better to use
-   :meth:`Task.cancel` instead of this function.
+   Synchronous trap. Cancel the indicated *task*.
 
 .. asyncfunction:: _wait_on_queue(kqueue, state_name)
 
-   Go to sleep on a queue. *kqueue* is an instance of a kernel queue
-   which is typically a :py:class:`collections.deque` instance. *state_name*
-   is the name of the wait state (used in debugging).
+   Blocking trap.  Go to sleep on a queue. *kqueue* is an instance of
+   a kernel queue which is typically a :py:class:`collections.deque`
+   instance. *state_name* is the name of the wait state (used in
+   debugging).
 
 .. asyncfunction:: _reschedule_tasks(kqueue, n=1, value=None, exc=None)
 
-   Reschedule one or more tasks from a queue. *kqueue* is an instance of a
-   kernel queue.  *n* is the number of tasks to release. *value* and *exc*
-   specify the return value or exception to raise in the task when it
-   resumes execution.
+   Synchronous trap. Reschedule one or more tasks from a
+   queue. *kqueue* is an instance of a kernel queue.  *n* is the
+   number of tasks to release. *value* and *exc* specify the return
+   value or exception to raise in the task when it resumes execution.
 
 .. asyncfunction:: _sigwatch(sigset)
 
@@ -1593,8 +1592,8 @@ timed-out.
 
 .. asyncfunction:: _sigwait(sigset)
 
-   Wait for the arrival of a signal in a given signal set. Returns the signal
-   number of the received signal.
+   Blocking trap. Wait for the arrival of a signal in a given signal
+   set. Returns the signal number of the received signal.
 
 .. asyncfunction:: _get_kernel()
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -265,8 +265,8 @@ def test_task_cancel(kernel):
 
     kernel.run(main())
     assert results == [
-            'start',
             'cancel start',
+            'start',
             'cancelling',
             'cancelled',
             'done',
@@ -322,8 +322,8 @@ def test_task_cancel_join(kernel):
 
     kernel.run(main())
     assert results == [
-            'start',
             'cancel start',
+            'start',
             'cancelling',
             'join cancel',
             'done',
@@ -359,9 +359,9 @@ def test_task_cancel_join_wait(kernel):
 
     kernel.run(main())
     assert results == [
-            'start',
             'cancel start',
             'join',
+            'start',
             'cancel',
             'join cancel',
             'done',
@@ -449,8 +449,8 @@ def test_task_ready_cancel(kernel):
     kernel.run(main())
 
     assert results == [
-            'child sleep',
             'parent sleep',
+            'child sleep',
             'cancel start',
             'child slept',
             'child cancelled',

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -273,7 +273,7 @@ def test_task_cancel(kernel):
             ]
 
 
-def test_task_cancel_no_wait(kernel):
+def test_task_cancel_not_blocking(kernel):
     async def child(e1, e2):
         await e1.set()
         try:
@@ -287,7 +287,7 @@ def test_task_cancel_no_wait(kernel):
         e2 = Event()
         task = await spawn(child(e1, e2))
         await e1.wait()
-        await task.cancel_no_wait()
+        await task.cancel(blocking=False)
         await e2.set()
         try:
             await task.join()
@@ -758,7 +758,7 @@ def test_defer_cancellation(kernel):
         e2 = Event()
         task = await spawn(cancel_me(e1, e2))
         await e1.wait()
-        await task.cancel_no_wait()
+        await task.cancel(blocking=False)
         await e2.set()
         await task.join()
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -38,9 +38,9 @@ def test_queue_simple(kernel):
             ('cons2', 1),
             ('cons1', 2),
             ('cons2', 3),
+            'producer_join',
             'cons1 done',
             'cons2 done',
-            'producer_join',
             'producer_done',
             ]
 
@@ -72,12 +72,12 @@ def test_queue_unbounded(kernel):
 
     assert results == [
             'producer_start',
+            'producer_join',
             ('cons1', 0),
             ('cons1', 1),
             ('cons1', 2),
             ('cons1', 3),
             'cons1 done',
-            'producer_join',
             'producer_done',
             ]
 
@@ -112,17 +112,17 @@ def test_queue_bounded(kernel):
 
     assert results == [
             'producer_start',
-            ('cons1', 0),
             ('produced', 0),
             ('produced', 1),
+            ('cons1', 0),
             ('produced', 2),
-            ('produced', 3),
             ('cons1', 1),
-            'producer_join',
+            ('produced', 3),
             ('cons1', 2),
+            'producer_join',
             ('cons1', 3),
-            'producer_done',
             'cons1 done',
+            'producer_done',
             ]
 
 def test_queue_get_cancel(kernel):
@@ -251,8 +251,8 @@ def test_queue_sync(kernel):
             ('cons2', 3),
             'producer_join',
             'cons1 done',
-            'producer_done',
             'cons2 done',
+            'producer_done',
             ]
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -91,8 +91,8 @@ class TestEvent:
         kernel.run(event_cancel(1))
 
         assert results == [
-                'event_wait',
                 'sleep',
+                'event_wait',
                 'cancel_start',
                 'event_cancel',
                 'cancel_done',
@@ -117,8 +117,8 @@ class TestEvent:
         kernel.run(event_run(1))
 
         assert results == [
-                'event_wait',
                 'sleep',
+                'event_wait',
                 'event_timeout',
                 'sleep_done',
                 ]
@@ -153,8 +153,8 @@ class TestEvent:
 
         kernel.run(event_run())
         assert results == [
-                'event_wait',
                 'sleep',
+                'event_wait',
                 'event_set',
                 'got event',
                 'event_set',
@@ -254,10 +254,10 @@ class TestLock:
                 True,
                 'work3 wait',
                 True,
-                'work2 acquire',
                 'work1 release',
-                'work3 acquire',
+                'work2 acquire',
                 'work2 release',
+                'work3 acquire',
                 'work3 release',
                 ]
 
@@ -284,8 +284,8 @@ class TestLock:
         kernel.run(worker_cancel(1))
 
         assert results == [
-                'lock_wait',
                 'sleep',
+                'lock_wait',
                 'cancel_start',
                 'lock_cancel',
                 'cancel_done',
@@ -313,8 +313,8 @@ class TestLock:
         kernel.run(worker_timeout(1))
 
         assert results == [
-                'lock_wait',
                 'sleep',
+                'lock_wait',
                 'lock_timeout',
                 'sleep_done',
                 ]
@@ -400,10 +400,10 @@ class TestSemaphore:
                 True,
                 'work3 wait',
                 True,
-                'work2 acquire',
                 'work1 release',
-                'work3 acquire',
+                'work2 acquire',
                 'work2 release',
+                'work3 acquire',
                 'work3 release',
                 ]
 
@@ -433,8 +433,8 @@ class TestSemaphore:
                 'work2 acquire',
                 'work3 wait',
                 True,
-                'work3 acquire',
                 'work1 release',
+                'work3 acquire',
                 'work2 release',
                 'work3 release',
                 ]
@@ -462,8 +462,8 @@ class TestSemaphore:
         kernel.run(worker_cancel(1))
 
         assert results == [
-                'lock_wait',
                 'sleep',
+                'lock_wait',
                 'cancel_start',
                 'lock_cancel',
                 'cancel_done',
@@ -491,8 +491,8 @@ class TestSemaphore:
         kernel.run(worker_timeout(1))
 
         assert results == [
-                'lock_wait',
                 'sleep',
+                'lock_wait',
                 'lock_timeout',
                 'sleep_done',
                 ]
@@ -596,8 +596,8 @@ class TestCondition:
         kernel.run(worker_cancel(1))
 
         assert results == [
-                'cond_wait',
                 'sleep',
+                'cond_wait',
                 'cancel_start',
                 'worker_cancel',
                 'cancel_done',
@@ -624,8 +624,8 @@ class TestCondition:
         kernel.run(worker_cancel(1))
 
         assert results == [
-                'cond_wait',
                 'sleep',
+                'cond_wait',
                 'worker_timeout',
                 'done'
                 ]
@@ -653,13 +653,13 @@ class TestCondition:
         kernel.run(worker_notify(1))
 
         assert results == [
-                'cond_wait',
-                'cond_wait',
-                'cond_wait',
                 'sleep',
+                'cond_wait',
+                'cond_wait',
+                'cond_wait',
                 'notify',
-                'wait_done',
                 'done',
+                'wait_done',
                 'wait_done',
                 'wait_done',
                 ]


### PR DESCRIPTION
This implements the ideas described in gh-101, esp.

  https://github.com/dabeaz/curio/issues/101#issuecomment-261477568

Specifically, it makes it so all traps are either "blocking" or
"synchronous", where those have consistent, well-defined meaning:
blocking traps trigger scheduling, are cancellation points, and are
timeout points; sync traps do none of those things. The trap handler
calling conventions in the kernel are adjusted to follow this.

Branch also contains some logically independent cleanups that fit in
with the changes I was making anyway:

- Cleaned up cancellation logic so that it no longer requires the
  cancelling task to race with the victim task.

- defer_cancellation now defers timeouts as well as cancel calls.

- Renamed Task.cancel_no_wait to Task.cancel(blocking=False)