### PR TITLE
Allow tasks to cancel themselves

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -523,9 +523,6 @@ class Kernel(object):
 
         # Cancel a task
         def _sync_trap_cancel_task(task):
-            if task == current:
-                raise CurioError("A task can't cancel itself")
-
             if task.cancelled:
                 return
             task.cancelled = True

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -810,6 +810,16 @@ def test_defer_cancellation_timeout(kernel):
     kernel.run(main(results))
     assert results == ["sleeping 1", "slept 1", "sleeping 2", "slept 2"]
 
+def test_self_cancellation(kernel):
+    async def suicidal_task():
+        task = await current_task()
+        await task.cancel(blocking=False)
+        # Cancellation is delivered the next time we block
+        with pytest.raises(CancelledError):
+            await sleep(0)
+
+    kernel.run(suicidal_task())
+
 def test_sleep_0_starvation(kernel):
     # This task should not block other tasks from running, and should be
     # cancellable. We used to have a bug where neither were true...


### PR DESCRIPTION
This is well-defined and easy to do with the new cancellation
implementation: the task just gets marked as being cancelled, and then
the next time it executes a blocking trap, the CancelledError is
raised.

Okay, so we *can* do it. But is it useful? Actually, yes. Here's the
situation where I ran into this: I have a "supervisor" whose job it is
to manage a set of child tasks. One of the operations the supervisor
exposes is a `shutdown` method, which tells the supervisor to stop
accepting new tasks and cancels all extant tasks. I tried having one
of the tasks that runs *inside* the supervisor call `shutdown`. This
is a perfectly sensible thing it do -- in fact, the whole idea here is
that you make the supervisor task the "main" task, and then run *all*
your code as sub-tasks under it. And that includes the code that
decides when its time to shut down your program. But, of course, this
means that this task ends up cancelling itself.