### PR TITLE
Improve task locals API

### DIFF
--- a/curio/local.py
+++ b/curio/local.py
@@ -87,6 +87,10 @@ def _copy_tasklocal(parent, child):
 # it if necessary.)  Normally would be a method on Local, but __getattribute__
 # makes that annoying. This is the simplest workaround.
 def _local_dict(local):
+    # forbid accessing attributes when no task is running, which is equivalent
+    # to using task local outside of any asynchronous code
+    if _current_task_local_storage.value is None:
+        raise RuntimeError('Accessing task local outside of the task context')
     return _current_task_local_storage.value.setdefault(local, {})
 
 

--- a/curio/local.py
+++ b/curio/local.py
@@ -62,6 +62,7 @@ from contextlib import contextmanager
 _current_task_local_storage = threading.local()
 _current_task_local_storage.value = None
 
+
 @contextmanager
 def _enable_tasklocal_for(task):
     # Using a full save/restore pattern here is a little paranoid, but
@@ -74,11 +75,13 @@ def _enable_tasklocal_for(task):
     finally:
         _current_task_local_storage.value = old
 
+
 # Called from _trap_spawn to implement task local inheritance.
 def _copy_tasklocal(parent, child):
     # Make a shallow copy of the values associated with each Local object.
     for local, values in parent.task_local_storage.items():
         child.task_local_storage[local] = dict(values)
+
 
 # Given a Local object, find its associated dict in the current task (creating
 # it if necessary.)  Normally would be a method on Local, but __getattribute__
@@ -86,24 +89,24 @@ def _copy_tasklocal(parent, child):
 def _local_dict(local):
     return _current_task_local_storage.value.setdefault(local, {})
 
+
+# make self.__dict__ point to the current task local storage
+def _patch_magic_dict(self):
+    object.__setattr__(self, '__dict__', _local_dict(self))
+
+
 class Local:
+
+    __slots__ = '__dict__',
+
     def __getattribute__(self, name):
-        if name == "__dict__":
-            return _local_dict(self)
-        try:
-            return _local_dict(self)[name]
-        except KeyError:
-            # "from None" preserves the context, but makes it hidden from
-            # tracebacks by default; see PEP 409
-            raise AttributeError(name) from None
+        _patch_magic_dict(self)
+        return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
-        _local_dict(self)[name] = value
+        _patch_magic_dict(self)
+        object.__setattr__(self, name, value)
 
     def __delattr__(self, name):
-        try:
-            del _local_dict(self)[name]
-        except KeyError:
-            # "from None" preserves the context, but makes it hidden from
-            # tracebacks by default; see PEP 409
-            raise AttributeError(name) from None
+        _patch_magic_dict(self)
+        return object.__delattr__(self, name)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -17,20 +17,21 @@ def run_with_real_exceptions(*args, **kwargs):
         e.__cause__ = None
         raise real from None
 
+
 def test_smoketest():
     local = Local()
 
     async def smoketest():
-        assert local.__dict__ == {}
+        assert vars(local) == {}
         local.a = 1
         assert local.a == 1
-        assert local.__dict__ == {"a": 1}
+        assert vars(local) == {"a": 1}
         del local.a
         with pytest.raises(AttributeError):
             local.a
         with pytest.raises(AttributeError):
             del local.a
-        assert local.__dict__ == {}
+        assert vars(local) == {}
 
         local.__dict__["b"] = 2
         assert local.b == 2

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -22,15 +22,18 @@ def test_smoketest():
     local = Local()
 
     async def smoketest():
+        assert local.__dict__ == {}
         assert vars(local) == {}
         local.a = 1
         assert local.a == 1
+        assert local.__dict__ == {"a": 1}
         assert vars(local) == {"a": 1}
         del local.a
         with pytest.raises(AttributeError):
             local.a
         with pytest.raises(AttributeError):
             del local.a
+        assert local.__dict__ == {}
         assert vars(local) == {}
 
         local.__dict__["b"] = 2


### PR DESCRIPTION
- use ```__slots__``` to decrease a memory footprint of ```curio.Local```
- ```vars()``` and ```dir()``` now work correctly when used with ```Local```
- forbid using ```Local``` outside of asynchronous context