### PR TITLE
Update conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,8 @@ exclude_patterns = ['_build']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+highlight_language = 'python3'
+
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 


### PR DESCRIPTION
This will fix python syntax highlighting on ReadTheDocs. Currently, async/await syntax is not highlighted.