### PR TITLE
Maintain a task tree in a kernel

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -619,6 +619,9 @@ class Kernel(object):
         def _sync_trap_get_current():
             return current
 
+        def _sync_trap_get_child_tasks(task):
+            return list(tasks[task.id][2])
+
         # Return the current value of the kernel clock
         def _sync_trap_clock():
             return time_monotonic()

--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -332,8 +332,12 @@ class Kernel(object):
             task.terminated = True
 
             _, parent, child_tasks = tasks[task.id]
+
+            # there are cases when parent is already gone from tasks, so
+            # we need to check if it is still there
             if parent is not None and parent.id in tasks:
                 tasks[parent.id][2].remove(task)
+            # set the maintask to be a new parent to avoid orphaned tasks
             for child in child_tasks:
                 tasks[child.id][1] = maintask
             del tasks[task.id]

--- a/curio/task.py
+++ b/curio/task.py
@@ -73,6 +73,9 @@ class Task(object):
         else:
             return self.next_value
 
+    async def child_tasks(self):
+        return await _get_child_tasks(self)
+
     async def cancel(self, blocking=True):
         '''
         Cancel a task by raising a CancelledError exception.

--- a/curio/task.py
+++ b/curio/task.py
@@ -74,6 +74,9 @@ class Task(object):
             return self.next_value
 
     async def child_tasks(self):
+        """
+        Get the list of all not terminated tasks spawned by this task
+        """
         return await _get_child_tasks(self)
 
     async def cancel(self, blocking=True):

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -16,7 +16,7 @@ __all__ = [
     '_join_task',
     '_wait_on_queue', '_reschedule_tasks', '_queue_reschedule_function',
     '_sigwatch', '_sigunwatch', '_sigwait', '_get_kernel', '_get_current',
-    '_set_timeout', '_unset_timeout', '_clock', 
+    '_get_child_tasks','_set_timeout', '_unset_timeout', '_clock',
     ]
 
 from types import coroutine
@@ -47,6 +47,8 @@ class SyncTraps(IntEnum):
     _sync_trap_reschedule_tasks = 10
     _sync_trap_cancel_allowed_stack_push = 11
     _sync_trap_cancel_allowed_stack_pop = 12
+    _sync_trap_get_child_tasks = 13
+
 
 globals().update((trap.name, trap) for trap in BlockingTraps)
 globals().update((trap.name, trap) for trap in SyncTraps)
@@ -203,3 +205,7 @@ def _clock():
     Return the value of the kernel clock
     '''
     return (yield (_sync_trap_clock,))
+
+@coroutine
+def _get_child_tasks(task):
+    return (yield (_sync_trap_get_child_tasks, task))

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -208,4 +208,7 @@ def _clock():
 
 @coroutine
 def _get_child_tasks(task):
+    """
+    Return the list of child tasks of the task
+    """
     return (yield (_sync_trap_get_child_tasks, task))


### PR DESCRIPTION
This PR introduces a new API for getting a list of child tasks for a particular tasks. This functionality is enabled by the change to the kernel data structure for storing tasks.

The new implementation of the kernel tasks data structure might serve as a ground up for an advanced task management, such as recursive task cancellations, for example.