### PR TITLE
Fix the name of a kwarg to the `abide` function

### DIFF
--- a/curio/sync.py
+++ b/curio/sync.py
@@ -326,7 +326,7 @@ def abide(op, *args, **kwargs):
     methods execute in a background thread.  Cancellation is handled
     gracefully. 
 
-    The reserve flag, if given exposes the background thread for further
+    The reserve_thread flag, if given exposes the background thread for further
     use.  This may be required for certain kinds of synchronization
     primitives such as condition variables:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1300,7 +1300,7 @@ synchronization primitives if you use the :func:`abide` function.
    an asynchronous context manager, it is returned unmodified.  If
    ``op`` is a synchronous context manager, it is wrapped in a manner
    that carries out its execution in a backing thread.  For this
-   latter case, a special keyword argument ``reserve=True`` may be
+   latter case, a special keyword argument ``reserve_thread=True`` may be
    given that instructs Curio to use the same backing thread for the
    entire duraction of the context manager.
 
@@ -1345,9 +1345,9 @@ If you wanted to trigger or wait for a thread-event, you might do this::
         evt.set()
         ...
 
-For condition variables and reentrant locks, you should use ``reserve=True`` keyword
-argument to make sure the same thread is used throughout the block. For
-example::
+For condition variables and reentrant locks, you should use
+``reserve_thread=True`` keyword argument to make sure the same thread is used
+throughout the block. For example::
 
     import curio
     import threading
@@ -1364,7 +1364,7 @@ example::
     # A curio task
     async def consumer(cond, items):
         while True:
-            async with abide(cond, reserve=True) as c:
+            async with abide(cond, reserve_thread=True) as c:
 	        while not items:
                     await c.wait()
                 item = items.popleft()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -820,7 +820,7 @@ class TestAbide:
     def test_abide_sync_rlock(self, kernel):
         results = []
         async def waiter(lck, evt):
-            async with abide(lck, reserve=True):
+            async with abide(lck, reserve_thread=True):
                 results.append('acquired')
             results.append('released')
             await abide(evt.set)


### PR DESCRIPTION
The kwarg is named `reserve_thread` not `reserve`, so use
`reserve_thread` consistently everywhere.