### PR TITLE
Don't try and select until after ready events have been processed

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -730,6 +730,7 @@ class Kernel(object):
         # Main Kernel Loop
         # ------------------------------------------------------------
         while njobs > 0:
+
             # Wait for an I/O event (or timeout)
             if ready:
                 timeout = 0
@@ -737,6 +738,54 @@ class Kernel(object):
                 timeout = sleeping[0][0] - time_monotonic()
             else:
                 timeout = None
+
+            try:
+                events = selector_select(timeout)
+            except OSError as e:
+                # If there is nothing to select, windows throws an
+                # OSError, so just set events to an empty list.
+                log.error('Exception %r from selector_select ignored ' % e,
+                          exc_info=True)
+                
+                events = []
+
+            # Reschedule tasks with completed I/O
+            for key, mask in events:
+                rtask, wtask = key.data
+                intfd = isinstance(key.fileobj, int)
+                if mask & EVENT_READ:
+                    # Discussion: If the associated fileobj is
+                    # *not* a bare integer file descriptor, we
+                    # keep a record of the last I/O event in
+                    # _last_io and leave the task registered on
+                    # the event loop.  If it performs the same I/O
+                    # operation again, it will get a speed boost
+                    # from not having to re-register its
+                    # event. However, it's not safe to use this
+                    # optimization with bare integer fds.  These
+                    # fds often get reused and there is a
+                    # possibility that a fd will get closed and
+                    # reopened on a different resource without it
+                    # being detected by the kernel.  For that case,
+                    # its critical that we not leave the fd on the
+                    # event loop.
+                    rtask._last_io = None if intfd else (key.fileobj, EVENT_READ)
+                    _reschedule_task(rtask)
+                    mask &= ~EVENT_READ
+                    rtask = None
+                if mask & EVENT_WRITE:
+                    wtask._last_io = None if intfd else (key.fileobj, EVENT_WRITE)
+                    _reschedule_task(wtask)
+                    mask &= ~EVENT_WRITE
+                    wtask = None
+
+                # Unregister the task if fileobj is not an integer fd (see
+                # note above).
+                if intfd:
+                    if mask:
+                        selector_modify(key.fileobj, mask, (rtask, wtask))
+                    else:
+                        selector_unregister(key.fileobj)
 
             # Process sleeping tasks (if any)
             if sleeping:
@@ -877,46 +926,6 @@ class Kernel(object):
                     if current._last_io:
                         _unregister_event(*current._last_io)
                         current._last_io = None
-
-            events = selector_select(timeout)
-
-            # Reschedule tasks with completed I/O
-            for key, mask in events:
-                rtask, wtask = key.data
-                intfd = isinstance(key.fileobj, int)
-                if mask & EVENT_READ:
-                    # Discussion: If the associated fileobj is
-                    # *not* a bare integer file descriptor, we
-                    # keep a record of the last I/O event in
-                    # _last_io and leave the task registered on
-                    # the event loop.  If it performs the same I/O
-                    # operation again, it will get a speed boost
-                    # from not having to re-register its
-                    # event. However, it's not safe to use this
-                    # optimization with bare integer fds.  These
-                    # fds often get reused and there is a
-                    # possibility that a fd will get closed and
-                    # reopened on a different resource without it
-                    # being detected by the kernel.  For that case,
-                    # its critical that we not leave the fd on the
-                    # event loop.
-                    rtask._last_io = None if intfd else (key.fileobj, EVENT_READ)
-                    _reschedule_task(rtask)
-                    mask &= ~EVENT_READ
-                    rtask = None
-                if mask & EVENT_WRITE:
-                    wtask._last_io = None if intfd else (key.fileobj, EVENT_WRITE)
-                    _reschedule_task(wtask)
-                    mask &= ~EVENT_WRITE
-                    wtask = None
-
-                # Unregister the task if fileobj is not an integer fd (see
-                # note above).
-                if intfd:
-                    if mask:
-                        selector_modify(key.fileobj, mask, (rtask, wtask))
-                    else:
-                        selector_unregister(key.fileobj)
 
 
         # If kernel shutdown has been requested, issue a cancellation request to all remaining tasks


### PR DESCRIPTION
Previous attempts to solve #75 included moving _init_loopback_task outside the main run() loop.

This fails to solve the problem because new tasks are simply added to the *ready* queue and that is not processed until the selector is called to look for new events.

This fixes #75 by moving the selector code and subsequent processing of events to the end of the run loop.

It does indeed solve the problem on windows, so far without an increase in stinging bat density.

It should be noted I'm quite out of my depth at this point, so proceed with caution!