### PR TITLE
Make Kernel.run() return coroutine's return value

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -264,7 +264,7 @@ class Kernel(object):
             raise RuntimeError('Only one Curio kernel per thread is allowed')
         self._local.running = True
         try:
-            self._run(coro, shutdown=shutdown)
+            return self._run(coro, shutdown=shutdown)
         finally:
             self._local.running = False
         

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -15,6 +15,30 @@ def test_hello(kernel):
     assert results == ['hello']
 
 
+def test_return(kernel):
+
+    async def hello():
+        return 'hello'
+
+    result = kernel.run(hello())
+    assert result == 'hello'
+
+
+def test_raise(kernel):
+
+    class Error(Exception):
+        pass
+
+    async def boom():
+        raise Error
+
+    try:
+        kernel.run(boom())
+        assert False, 'boom() did not raise'
+    except TaskError as exc:
+        assert isinstance(exc.__cause__, Error)
+
+
 def test_sleep(kernel):
     results = []
     async def main():


### PR DESCRIPTION
[Reference](https://github.com/dabeaz/curio/blob/master/docs/reference.rst) specifies that `Kernel.run()` should "run the coroutine
*coro* to completion and return its final return value."