### PR TITLE
Websocket example.

### DIFF
--- a/examples/ws_server.py
+++ b/examples/ws_server.py
@@ -1,0 +1,88 @@
+"""A Curio websocket server.
+
+pip install wsproto before running this.
+
+"""
+from curio import Queue, run, spawn, wait
+from curio.socket import IPPROTO_TCP, TCP_NODELAY
+from wsproto.connection import WSConnection, SERVER
+from wsproto.events import (ConnectionClosed, ConnectionRequested, TextReceived,
+                            BytesReceived)
+
+DATA_TYPES = (TextReceived, BytesReceived)
+
+
+async def ws_adapter(in_q, out_q, client, _):
+    """A simple, queue-based Curio-Sans-IO websocket bridge."""
+    client.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+    wsconn = WSConnection(SERVER)
+    closed = False
+
+    while not closed:
+        wstask = await spawn(client.recv(65535))
+        outqtask = await spawn(out_q.get())
+        async with wait((wstask, outqtask)) as w:
+            task = await w.next_done()
+            result = await task.join()
+
+        if task is wstask:
+            wsconn.receive_bytes(result)
+
+            for event in wsconn.events():
+                cl = event.__class__
+                if cl in DATA_TYPES:
+                    await in_q.put(event.data)
+                elif cl is ConnectionRequested:
+                    # Auto accept. Maybe consult the handler?
+                    wsconn.accept(event)
+                elif cl is ConnectionClosed:
+                    # The client has closed the connection.
+                    await in_q.put(None)
+                    closed = True
+                else:
+                    print(event)
+            await client.sendall(wsconn.bytes_to_send())
+        else:
+            # We got something from the out queue.
+            if result is None:
+                # Terminate the connection.
+                print("Closing the connection.")
+                wsconn.close()
+                closed = True
+            else:
+                wsconn.send_data(result)
+            payload = wsconn.bytes_to_send()
+            await client.sendall(payload)
+    print("Bridge done.")
+
+
+async def ws_echo_server(in_queue, out_queue):
+    """Just echo websocket messages, reversed. Echo 3 times, then close."""
+    for _ in range(3):
+        msg = await in_queue.get()
+        if msg is None:
+            # The ws connection was closed.
+            break
+        await out_queue.put(msg[::-1])
+    print("Handler done.")
+
+
+def serve_ws(handler):
+    """Start processing web socket messages using the given handler."""
+    async def run_ws(client, addr):
+        in_q, out_q = Queue(), Queue()
+        ws_task = await spawn(ws_adapter(in_q, out_q, client, addr))
+        await handler(in_q, out_q)
+        await out_q.put(None)
+        await ws_task.join()  # Wait until it's done.
+        # Curio will close the socket for us after we drop off here.
+        print("Master task done.")
+
+    return run_ws
+
+
+if __name__ == '__main__':
+    from curio import tcp_server
+    port = 5000
+    print(f'Listening on port {port}.')
+    run(tcp_server('', port, serve_ws(ws_echo_server)))


### PR DESCRIPTION
Hi!

Keep in mind I have Python async-y experience (I wrote aiofiles and pytest-asyncio) but I'm a Curio novice.

This is what I've been playing with. The websocket protocol implementation is from https://github.com/jeamland/wsproto. Wsproto is written in the sans-io style, i.e. the protocol logic but without any I/O. This is super for us, since we can just glue this to Curio easily.

I guess my idea was to expect users to implement handlers using two queues. There's an in queue, where you get stuff sent by a client, and an out queue where you put stuff to send to the client.

So this is what a user might write (as seen below in the code):
```
async def ws_echo_server(in_queue, out_queue):
    """Just echo websocket messages, reversed. Echo 3 times, then close."""
    for _ in range(3):
        msg = await in_queue.get()
        if msg is None:
            # The ws connection was closed.
            break
        await out_queue.put(msg[::-1])
    print("Handler done.")
```

If `None` comes out the in queue, it means the client has closed the connection. The handler can choose to keep running. If the handler just returns, the connection will be closed. Or the handler can put `None` into the out queue to close the connection and keep running. In normal communication, strings or bytes go through the queues.

Then they run it like this:
```
curio.run(tcp_server('', port, serve_ws(ws_echo_server)))
```

We provide everything else (including `serve_ws`). This might actually be a bad layer to do this, since websockets are reachable over URLs. Users might want to have multiple handlers on a popular port, like 80. So this can be refactored. Does Curio have any HTTP support?

I'm not sure how to handle backpressure correctly. Probably limit the queue sizes? If the client overwhelms the server, the in queue will block so the glue code will stop reading from the socket and so propagate the backpressure. Similarly for the out queue.

Receive timeouts can be handler by the usual Curio mechanisms. Not sure about write timeouts.