### PR TITLE
Add basic curio -> asyncio coroutine bridge.

### DIFF
--- a/curio/__init__.py
+++ b/curio/__init__.py
@@ -13,6 +13,7 @@ from .network import *
 from .file import *
 from .local import *
 from .channel import *
+from .bridge import *
 
 __all__ = [*errors.__all__,
            *task.__all__,
@@ -25,4 +26,5 @@ __all__ = [*errors.__all__,
            *file.__all__,
            *local.__all__,
            *channel.__all__,
+           *bridge.__all__,
            ]

--- a/curio/bridge.py
+++ b/curio/bridge.py
@@ -1,0 +1,32 @@
+# bridge.py
+#
+# Support for running asyncio coroutines from within curio.
+# The curio->asyncio bridge runs a separate asyncio event loop in a different thread,
+# which has coroutines submitted to it over the course of the kernel's lifetime.
+
+import asyncio
+
+from .traps import _get_kernel
+from .sync import Event, abide
+
+
+async def acb(coro):
+    '''
+    Runs a coroutine in the current event loop running alongside this kernel.
+    '''
+    kernel = await _get_kernel()
+    finished_ev = Event()
+    # How this works:
+    # First, it schedules a new coroutine on the kernel's asyncio loop,
+    # which will be running alongside.
+    # Then, it will simply wait for the result in another thread (yay threading!)
+    #
+    # Possible improvements:
+    #  1) Wrap the future in a Task which can be `.join`'d on rather than
+    #     waiting on an event.
+    #  2) Force the user to pass their own loop in, instead of having the kernel
+    #     manage it.
+    loop = kernel._asyncio_loop
+    fut = asyncio.run_coroutine_threadsafe(coro, loop)
+
+    return await abide(fut.result)

--- a/curio/bridge.py
+++ b/curio/bridge.py
@@ -9,6 +9,8 @@ import asyncio
 from .traps import _get_kernel
 from .sync import Event, abide
 
+__all__ = ["acb"]
+
 
 async def acb(coro):
     '''

--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -1,7 +1,6 @@
 # curio/kernel.py
 #
 # Main execution kernel.
-import asyncio
 import socket
 import heapq
 import time

--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -1,7 +1,7 @@
 # curio/kernel.py
 #
 # Main execution kernel.
-
+import asyncio
 import socket
 import heapq
 import time
@@ -172,7 +172,7 @@ class Kernel(object):
     _local = threading.local()
 
     def __init__(self, *, selector=None, with_monitor=False, log_errors=True,
-                 warn_if_task_blocks_for=None):
+                 warn_if_task_blocks_for=None, with_asyncio_bridge=False, asyncio_loop=None):
         if selector is None:
             selector = DefaultSelector()
 
@@ -204,6 +204,23 @@ class Kernel(object):
         # Optional process/thread pools (see workers.py)
         self._thread_pool = None
         self._process_pool = None
+
+        # Optional asyncio bridge
+        self._asyncio_bridge = None
+        self._asyncio_loop = None
+
+        if with_asyncio_bridge:
+            # Start the event loop in a separate thread.
+            # This will be managed by the kernel `run` loop later on.
+            import asyncio
+            self._asyncio_loop = asyncio_loop or asyncio.new_event_loop()
+
+            def _asyncio_thread():
+                asyncio.set_event_loop(self._asyncio_loop)
+                self._asyncio_loop.run_forever()
+                print("loop died")
+
+            self._asyncio_bridge = _asyncio_thread
 
         # Optional settings
         self._warn_if_task_blocks_for = warn_if_task_blocks_for
@@ -297,6 +314,10 @@ class Kernel(object):
             self._process_pool.shutdown()
             self._process_pool = None
 
+        if self._asyncio_loop:
+            self._asyncio_loop.stop()
+            self._asyncio_loop = None
+
         if self._monitor:
             self._monitor.close()
 
@@ -317,6 +338,13 @@ class Kernel(object):
                     self._asyncgen_hooks = sys.get_asyncgen_hooks()
                 self._runner = self._run_coro()
                 self._runner.send(None)
+
+            # Boot the asyncio worker thread, if applicable.
+            if self._asyncio_loop:
+                # asyncio must die when we die
+                # because it is terribad and won't stop running
+                self._local.asyncio_thread = threading.Thread(target=self._asyncio_bridge, daemon=True)
+                self._local.asyncio_thread.start()
 
             # Submit the given coroutine (if any)
             try:


### PR DESCRIPTION
This allows you to run asyncio coroutines from within curio, using a new function `curio.acb` (Asyncio Curio Bridge). 

I put this inside the kernel because it's the easiest and most user-friendly way of co-operating the two event loop types.

The `asyncio` event loop runs inside a thread that is booted when `curio.run()` starts, and stops when it exits. asyncio coroutines are submitted to the worker event loop via `run_coroutine_threadsafe` and the resulting future is then awaited on. 

Right now, there's no additional tests or documentation.