### PR TITLE
Add the ability to customize the task ID from `spawn`.

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -399,9 +399,9 @@ class Kernel(object):
         # ---- Task Support Functions
 
         # Create a new task. Putting it on the ready queue
-        def _new_task(coro, daemon=False):
+        def _new_task(coro, daemon=False, taskid=None):
             nonlocal njobs
-            task = Task(coro, daemon)
+            task = Task(coro, daemon, taskid=taskid)
             tasks[task.id] = task
             if not daemon:
                 njobs += 1
@@ -557,8 +557,8 @@ class Kernel(object):
 
         # Add a new task to the kernel
         @nonblocking
-        def _trap_spawn(coro, daemon):
-            task = _new_task(coro, daemon | current.daemon)    # Inherits daemonic status from parent
+        def _trap_spawn(coro, daemon, task_id):
+            task = _new_task(coro, daemon | current.daemon, task_id)    # Inherits daemonic status from parent
             task.parentid = current.id
             _copy_tasklocal(current, task)
             return task

--- a/curio/side.py
+++ b/curio/side.py
@@ -37,7 +37,7 @@ def main(argv):
         sys.modules['__main__'] = mod
     (corofunc, args) = pickle.loads(base64.b64decode(sys.argv[2]))
     try:
-        run(_aside_child(corofunc, args)
+        run(_aside_child(corofunc, args))
     except CancelledError as e:
         raise SystemExit(1)
 

--- a/curio/task.py
+++ b/curio/task.py
@@ -155,7 +155,7 @@ async def schedule():
     '''
     await sleep(0)
 
-async def spawn(corofunc, *args, daemon=False, allow_cancel=True):
+async def spawn(corofunc, *args, daemon=False, allow_cancel=True, taskid=None):
     '''
     Create a new task, running corofunc(*args). Use the daemon=True
     option if the task runs forever as a background task.  If
@@ -166,7 +166,7 @@ async def spawn(corofunc, *args, daemon=False, allow_cancel=True):
         coro = corofunc
     else:
         coro = corofunc(*args)
-    task = await _spawn(coro, daemon)
+    task = await _spawn(coro, daemon, taskid)
     task.allow_cancel = allow_cancel
     return task
 

--- a/curio/traps.py
+++ b/curio/traps.py
@@ -87,11 +87,11 @@ def _sleep(clock, absolute):
 
 
 @coroutine
-def _spawn(coro, daemon):
+def _spawn(coro, daemon, taskid=None):
     '''
     Create a new task. Returns the resulting Task object.
     '''
-    return (yield _trap_spawn, coro, daemon)
+    return (yield _trap_spawn, coro, daemon, taskid)
 
 
 @coroutine

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -84,7 +84,7 @@ Tasks
 
 The following functions are defined to help manage the execution of tasks.
 
-.. asyncfunction:: spawn(coro, daemon=False)
+.. asyncfunction:: spawn(coro, daemon=False, allow_cancel=True, task_id=None)
 
    Create a new task that runs the coroutine *coro*.  Returns a
    :class:`Task` instance as a result.  The *daemon* option, if

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1037,3 +1037,12 @@ def test_task_gather_timeout(kernel):
         
     kernel.run(main)
 
+def test_custom_task_id(kernel):
+    async def t():
+        return
+
+    async def main():
+        nt = await spawn(t(), taskid=797)
+        assert nt.id == 797
+
+    kernel.run(main)


### PR DESCRIPTION
`Task` had the ability to pass a task ID, but this was never used anywhere. 