### PR TITLE
add python3.6 asynchronous generator function support for AsyncABC

### DIFF
--- a/curio/meta.py
+++ b/curio/meta.py
@@ -81,7 +81,7 @@ def iscoroutinefunction(func):
         return iscoroutinefunction(func.func)
     if hasattr(func, '__func__'):
         return iscoroutinefunction(func.__func__)
-    return inspect.iscoroutinefunction(func) or hasattr(func, '_awaitable')
+    return inspect.iscoroutinefunction(func) or hasattr(func, '_awaitable') or inspect.isasyncgenfunction(func)
 
 def instantiate_coroutine(corofunc, *args, **kwargs):
     '''
@@ -248,10 +248,10 @@ class AsyncABCMeta(ABCMeta):
         coros = {}
         for base in reversed(cls.__mro__):
             coros.update((name, val) for name, val in vars(base).items()
-                         if inspect.iscoroutinefunction(val))
+                         if iscoroutinefunction(val))
 
         for name, val in vars(cls).items():
-            if name in coros and not inspect.iscoroutinefunction(val):
+            if name in coros and not iscoroutinefunction(val):
                 raise TypeError('Must use async def %s%s' % (name, inspect.signature(val)))
         super().__init__(name, bases, methods)
 

--- a/curio/meta.py
+++ b/curio/meta.py
@@ -52,6 +52,12 @@ _CO_ITERABLE_COROUTINE = 0x0100
 _CO_ASYNC_GENERATOR = 0x0200
 _CO_FROM_COROUTINE = _CO_COROUTINE | _CO_ITERABLE_COROUTINE | _CO_ASYNC_GENERATOR
 
+try:
+    _isasyncgenfunction = inspect.isasyncgenfunction
+except AttributeError:
+    # Not supported in python 3.5
+    _isasyncgenfunction = lambda func: False
+
 def _from_coroutine(level=2):
     f_code = _getframe(level).f_code
     if f_code.co_flags & _CO_FROM_COROUTINE:
@@ -81,7 +87,7 @@ def iscoroutinefunction(func):
         return iscoroutinefunction(func.func)
     if hasattr(func, '__func__'):
         return iscoroutinefunction(func.__func__)
-    return inspect.iscoroutinefunction(func) or hasattr(func, '_awaitable') or inspect.isasyncgenfunction(func)
+    return inspect.iscoroutinefunction(func) or hasattr(func, '_awaitable') or _isasyncgenfunction(func)
 
 def instantiate_coroutine(corofunc, *args, **kwargs):
     '''

--- a/tests/test_asyncgen.py
+++ b/tests/test_asyncgen.py
@@ -2,7 +2,7 @@
 
 import pytest
 from curio import *
-from curio.meta import finalize, awaitable, safe_generator
+from curio.meta import finalize, awaitable, safe_generator, AsyncABC, abstractmethod
 
 
 # Test to make sure a simple async generator runs
@@ -193,6 +193,13 @@ def test_agen_safe_override(kernel):
 
     kernel.run(main())
 
+def test_asyncapc_generator_function():
+    class Parent(AsyncABC):
+        @abstractmethod
+        async def foo(self):
+            raise NotImplementedError
 
-
-
+    class Child(Parent):
+        async def foo(self):
+            yield 1
+            return

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,6 +1,5 @@
 from curio import meta
 from curio import *
-import time
 from functools import partial
 import pytest
 
@@ -71,6 +70,18 @@ def test_async_abc():
             pass
 
 
+def test_async_abstractmethod():
+    class Parent(meta.AsyncABC):
+        @meta.abstractmethod
+        async def foo(self):
+            raise NotImplementedError
+
+    class Child(Parent):
+        async def foo(self):
+            yield 1
+            return
+
+
 def test_sync_only(kernel):
     @meta.sync_only
     def func():
@@ -93,8 +104,6 @@ def test_bad_awaitable():
         def spam(x, y, z):
             pass
 
-
-from functools import partial
 
 def test_awaitable_partial(kernel):
     def func(x, y, z):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -70,18 +70,6 @@ def test_async_abc():
             pass
 
 
-def test_async_abstractmethod():
-    class Parent(meta.AsyncABC):
-        @meta.abstractmethod
-        async def foo(self):
-            raise NotImplementedError
-
-    class Child(Parent):
-        async def foo(self):
-            yield 1
-            return
-
-
 def test_sync_only(kernel):
     @meta.sync_only
     def func():


### PR DESCRIPTION
This fix issue: #217
Add support for Python3.6 asynchronous generator function in curio.meta.iscoroutinefunction function.