### PR TITLE
Add `readable` method to Socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ docs/_build
 __pycache__/
 .vscode
 venv*
+*.egg-info
 
 benchmarks/curio/
 benchmarks/env/

--- a/curio/io.py
+++ b/curio/io.py
@@ -193,6 +193,12 @@ class Socket(object):
         '''
         await _write_wait(self._fileno)
 
+    async def readable(self):
+        '''
+        Waits until the socket is readable.
+        '''
+        await _read_wait(self._fileno)
+
     async def accept(self):
         while True:
             try:


### PR DESCRIPTION
I need this method for HTTP keep-alive check, and I found there is a `writeable` method but no `readable` method, here is the demo code for my use case:

```python
try:
    await timeout_after(self.keep_alive_timeout, cli_sock.readable())
except TaskTimeout as ex:
    await cli_sock.close()
```