### PR TITLE
Make tests work with pytest-xdist (partial #264)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -429,6 +429,7 @@ Contributors
 - Nathaniel Smith
 - Alexander Zhukov
 - Laura Dickinson
+- Sandeep Gupta
 
 About
 -----

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import socket
 import sys
 import pytest
 from curio import Kernel
@@ -11,6 +12,16 @@ def kernel(request):
     request.addfinalizer(lambda: k.run(shutdown=True))
     request.addfinalizer(m.close)
     return k
+
+
+# This is based on https://unix.stackexchange.com/a/132524
+@pytest.fixture(scope='function')
+def portno():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('', 0))
+    _, port = s.getsockname()
+    s.close()
+    return port
 
 collect_ignore = []
 if sys.version_info < (3,6):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -120,9 +120,9 @@ def test_bad_usage(kernel):
 wlines = ['line1\n', 'line2\n', 'line3\n']
 
 
-def test_write(kernel):
+def test_write(kernel, tmpdir):
     async def main():
-        outname = os.path.join(dirname, 'tmp.txt')
+        outname = tmpdir.join('tmp.txt')
         async with aopen(outname, 'w') as f:
             outdata = ''.join(wlines)
             await f.write(outdata)
@@ -133,9 +133,9 @@ def test_write(kernel):
     kernel.run(main())
 
 
-def test_writelines(kernel):
+def test_writelines(kernel, tmpdir):
     async def main():
-        outname = os.path.join(dirname, 'tmp.txt')
+        outname = tmpdir.join('tmp.txt')
         async with aopen(outname, 'w') as f:
             await f.writelines(wlines)
 
@@ -156,9 +156,9 @@ def test_seek_tell(kernel):
 
     kernel.run(main())
 
-def test_truncate(kernel):
+def test_truncate(kernel, tmpdir):
     async def main():
-        outname = os.path.join(dirname, 'tmp.txt')
+        outname = tmpdir.join('tmp.txt')
         async with aopen(outname, 'wb') as f:
             await f.write(b'12345')
             await f.flush()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,7 @@ import io
 import socket as std_socket
 import pytest
 
-def test_socket_blocking(kernel):
+def test_socket_blocking(kernel, portno):
     '''
     Test of exposing a socket in blocking mode
     '''
@@ -37,8 +37,8 @@ def test_socket_blocking(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -53,7 +53,7 @@ def test_socket_blocking(kernel):
     ]
 
 
-def test_socketstream_blocking(kernel):
+def test_socketstream_blocking(kernel, portno):
     '''
     Test of exposing a socket stream in blocking mode
     '''
@@ -84,8 +84,8 @@ def test_socketstream_blocking(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -99,7 +99,7 @@ def test_socketstream_blocking(kernel):
     ]
 
 
-def test_filestream_blocking(kernel):
+def test_filestream_blocking(kernel, portno):
     '''
     Test of exposing a socket in blocking mode
     '''
@@ -130,8 +130,8 @@ def test_filestream_blocking(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -145,7 +145,7 @@ def test_filestream_blocking(kernel):
     ]
 
 
-def test_filestream_bad_blocking(kernel):
+def test_filestream_bad_blocking(kernel, portno):
     '''
     Test of exposing a socket in blocking mode with buffered data error
     '''
@@ -175,8 +175,8 @@ def test_filestream_bad_blocking(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -184,7 +184,7 @@ def test_filestream_bad_blocking(kernel):
     kernel.run(main())
     assert results[0]
 
-def test_socketstream_bad_blocking(kernel):
+def test_socketstream_bad_blocking(kernel, portno):
     '''
     Test of exposing a socket in blocking mode with buffered data error
     '''
@@ -214,8 +214,8 @@ def test_socketstream_bad_blocking(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -223,7 +223,7 @@ def test_socketstream_bad_blocking(kernel):
     kernel.run(main())
     assert results[0]
 
-def test_read_partial(kernel):
+def test_read_partial(kernel, portno):
     done = Event()
     results = []
     async def handler(client, addr):
@@ -248,8 +248,8 @@ def test_read_partial(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -257,7 +257,7 @@ def test_read_partial(kernel):
     kernel.run(main())
     assert results == [ b'hello\n', b'wo', b'rld\n']
 
-def test_readall(kernel):
+def test_readall(kernel, portno):
     done = Event()
     results = []
 
@@ -284,8 +284,8 @@ def test_readall(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -299,7 +299,7 @@ def test_readall(kernel):
     ]
 
 
-def test_readall_partial(kernel):
+def test_readall_partial(kernel, portno):
     done = Event()
 
     async def handler(client, addr):
@@ -320,8 +320,8 @@ def test_readall_partial(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -329,7 +329,7 @@ def test_readall_partial(kernel):
     kernel.run(main())
 
 
-def test_readall_timeout(kernel):
+def test_readall_timeout(kernel, portno):
     done = Event()
     results = []
 
@@ -354,8 +354,8 @@ def test_readall_timeout(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -369,7 +369,7 @@ def test_readall_timeout(kernel):
     ]
 
 
-def test_read_exactly(kernel):
+def test_read_exactly(kernel, portno):
     done = Event()
     results = []
 
@@ -390,8 +390,8 @@ def test_read_exactly(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -407,7 +407,7 @@ def test_read_exactly(kernel):
     ]
 
 
-def test_read_exactly_incomplete(kernel):
+def test_read_exactly_incomplete(kernel, portno):
     done = Event()
     results = []
     async def handler(client, addr):
@@ -428,8 +428,8 @@ def test_read_exactly_incomplete(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -438,7 +438,7 @@ def test_read_exactly_incomplete(kernel):
 
     assert results[0] ==  b'Msg1\nMsg2\nMsg3\n'
 
-def test_read_exactly_timeout(kernel):
+def test_read_exactly_timeout(kernel, portno):
     done = Event()
     results = []
 
@@ -465,8 +465,8 @@ def test_read_exactly_timeout(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -481,7 +481,7 @@ def test_read_exactly_timeout(kernel):
 
 
 
-def test_readline(kernel):
+def test_readline(kernel, portno):
     done = Event()
     results = []
 
@@ -502,8 +502,8 @@ def test_readline(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -519,7 +519,7 @@ def test_readline(kernel):
     ]
 
 
-def test_readlines(kernel):
+def test_readlines(kernel, portno):
     done = Event()
     results = []
 
@@ -539,8 +539,8 @@ def test_readlines(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -556,7 +556,7 @@ def test_readlines(kernel):
     ]
 
 
-def test_readlines_timeout(kernel):
+def test_readlines_timeout(kernel, portno):
     done = Event()
     results = []
 
@@ -582,8 +582,8 @@ def test_readlines_timeout(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -598,7 +598,7 @@ def test_readlines_timeout(kernel):
     ]
 
 
-def test_writelines(kernel):
+def test_writelines(kernel, portno):
     done = Event()
     results = []
 
@@ -619,8 +619,8 @@ def test_writelines(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -634,7 +634,7 @@ def test_writelines(kernel):
     ]
 
 
-def test_writelines_timeout(kernel):
+def test_writelines_timeout(kernel, portno):
     done = Event()
     results = []
     async def handler(client, addr):
@@ -662,8 +662,8 @@ def test_writelines_timeout(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -673,7 +673,7 @@ def test_writelines_timeout(kernel):
     assert results[0] == len(results[1])
 
 
-def test_write_timeout(kernel):
+def test_write_timeout(kernel, portno):
     done = Event()
     results = []
     async def handler(client, addr):
@@ -696,8 +696,8 @@ def test_write_timeout(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -706,7 +706,7 @@ def test_write_timeout(kernel):
 
     assert results[0] == len(results[1])
 
-def test_iterline(kernel):
+def test_iterline(kernel, portno):
     results = []
 
     async def handler(client, addr):
@@ -727,8 +727,8 @@ def test_iterline(kernel):
 
     async def main():
         async with TaskGroup() as g:
-            serv = await g.spawn(tcp_server, '', 25000, handler)
-            await g.spawn(test_client, ('localhost', 25000), serv)
+            serv = await g.spawn(tcp_server, '', portno, handler)
+            await g.spawn(test_client, ('localhost', portno), serv)
 
     kernel.run(main())
 
@@ -741,7 +741,7 @@ def test_iterline(kernel):
     ]
 
 
-def test_double_recv(kernel):
+def test_double_recv(kernel, portno):
     done = Event()
     results = []
 
@@ -772,8 +772,8 @@ def test_double_recv(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        client = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        client = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await client.join()
@@ -788,7 +788,7 @@ def test_double_recv(kernel):
         'handler done'
         ]
 
-def test_sendall_cancel(kernel):
+def test_sendall_cancel(kernel, portno):
     done = Event()
     start = Event()
     results = {}
@@ -815,8 +815,8 @@ def test_sendall_cancel(kernel):
         await sock.close()
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        t = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        t = await spawn(test_client, ('localhost', portno), serv)
         await sleep(0.1)
         await t.cancel()
         await start.set()
@@ -828,7 +828,7 @@ def test_sendall_cancel(kernel):
     assert results['handler'] == results['sender']
 
 
-def test_stream_bad_context(kernel):
+def test_stream_bad_context(kernel, portno):
     done = Event()
     results = []
     async def handler(client, addr):
@@ -850,8 +850,8 @@ def test_stream_bad_context(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()
@@ -860,7 +860,7 @@ def test_stream_bad_context(kernel):
 
     assert results == [ True ]
 
-def test_stream_bad_iter(kernel):
+def test_stream_bad_iter(kernel, portno):
     done = Event()
     results = []
     async def handler(client, addr):
@@ -883,8 +883,8 @@ def test_stream_bad_iter(kernel):
 
 
     async def main():
-        serv = await spawn(tcp_server, '', 25000, handler)
-        c = await spawn(test_client, ('localhost', 25000), serv)
+        serv = await spawn(tcp_server, '', portno, handler)
+        c = await spawn(test_client, ('localhost', portno), serv)
         await done.wait()
         await serv.cancel()
         await c.join()

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -6,7 +6,7 @@ from curio import *
 from curio.socket import *
 from curio import io
 
-def test_tcp_echo(kernel):
+def test_tcp_echo(kernel, portno):
     results = []
     async def server(address):
         sock = socket(AF_INET, SOCK_STREAM)
@@ -48,8 +48,8 @@ def test_tcp_echo(kernel):
 
     async def main():
         async with TaskGroup() as g:
-            await g.spawn(server, ('', 25000))
-            await g.spawn(client, ('localhost', 25000))
+            await g.spawn(server, ('', portno))
+            await g.spawn(client, ('localhost', portno))
 
     kernel.run(main())
 
@@ -70,7 +70,7 @@ def test_tcp_echo(kernel):
     ]
 
 
-def test_tcp_file_echo(kernel):
+def test_tcp_file_echo(kernel, portno):
     results = []
     async def server(address):
         sock = socket(AF_INET, SOCK_STREAM)
@@ -110,8 +110,8 @@ def test_tcp_file_echo(kernel):
 
     async def main():
         async with TaskGroup() as g:
-             await g.spawn(server, ('', 25000))
-             await g.spawn(client, ('localhost', 25000))
+             await g.spawn(server, ('', portno))
+             await g.spawn(client, ('localhost', portno))
 
     kernel.run(main())
 
@@ -170,7 +170,7 @@ def test_udp_echo(kernel):
     ]
 
 
-def test_accept_timeout(kernel):
+def test_accept_timeout(kernel, portno):
     results = []
     async def server(address):
         sock = socket(AF_INET, SOCK_STREAM)
@@ -185,7 +185,7 @@ def test_accept_timeout(kernel):
             results.append('accept timeout')
         await sock.close()
 
-    kernel.run(server(('', 25000)))
+    kernel.run(server(('', portno)))
 
     assert results == [
         'accept wait',
@@ -193,7 +193,7 @@ def test_accept_timeout(kernel):
     ]
 
 
-def test_accept_cancel(kernel):
+def test_accept_cancel(kernel, portno):
     results = []
     async def server(address):
         sock = socket(AF_INET, SOCK_STREAM)
@@ -209,7 +209,7 @@ def test_accept_cancel(kernel):
         await sock.close()
 
     async def canceller():
-        task = await spawn(server, ('', 25000))
+        task = await spawn(server, ('', portno))
         await sleep(0.5)
         await task.cancel()
 


### PR DESCRIPTION
Two main changes:
 1. use a pytest fixture tmpdir for writing to a file ephemerally
 2. write a portno fixture to get an 'almost' unique port no