### PR TITLE
Wait for wrapped futures directly in get and put

### DIFF
--- a/curio/queue.py
+++ b/curio/queue.py
@@ -255,7 +255,7 @@ class UniversalQueue(object):
     async def get(self):
         item, fut = self._get()
         if fut:
-            await asyncio.wait_for(asyncio.wrap_future(fut), None)
+            await asyncio.wrap_future(fut)
             item = fut.result()
         return item
 
@@ -322,7 +322,7 @@ class UniversalQueue(object):
             fut = self._put(item)
             if not fut:
                 break
-            await asyncio.wait_for(asyncio.wrap_future(fut), None)
+            await asyncio.wrap_future(fut)
 
     def task_done_sync(self):
         with self._all_tasks_done:


### PR DESCRIPTION
This patch removes the call with asyncio.wait_for in the asyncio versions of UniversalQueue.put and get. Since Asyncio can directly await wrapped futures. Using asyncio.wait_for with a timeout of zero does nothing.

Closes #267 