### PR TITLE
Fix AsyncCountdownIter example in docs/devel.rst

### DIFF
--- a/docs/devel.rst
+++ b/docs/devel.rst
@@ -179,7 +179,7 @@ You can also define an asynchronous iterator::
 
         async def __anext__(self):
             self.n -= 1
-            if self.n <= 0:
+            if self.n < 0:
                 raise StopAsyncIteration
             return self.n + 1
 


### PR DESCRIPTION
This is how the example should run:
```
>>> run(main)
T-minus 5
T-minus 4
T-minus 3
T-minus 2
T-minus 1
```
Prior to this fix, it stops at 2:
```
>>> run(main)
T-minus 5
T-minus 4
T-minus 3
T-minus 2
```