### PR TITLE
fork to spawn

### DIFF
--- a/curio/workers.py
+++ b/curio/workers.py
@@ -343,7 +343,7 @@ class ProcessWorker(object):
         self.pool = pool
 
     def _launch(self):
-        context = multiprocessing.get_context('fork')
+        context = multiprocessing.get_context('spawn')
         client_ch, server_ch = context.Pipe()
         self.process = context.Process(
             target=self.run_server, args=(server_ch, ), daemon=True)


### PR DESCRIPTION
Hey David (@dabeaz), a one-liner fix to `spawn` because process pool workers are expected to be "clean" interpreters as you mention [here](https://github.com/dabeaz/curio/issues/165#issuecomment-385264390). We were getting unexpected behaviour with the current version using `fork` because the new processes would have Curio kernel running (curio.meta.curio_running() was True). Test suite seems to pass as before. Thanks!