### PR TITLE
Travis: Run tests on Windows too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,22 @@ matrix:
     - language: python
       python: 3.6
       os: linux
+    - os: windows
+      language: sh # Python is not yet officially supported
+  allow_failures:
+    - os: windows
+      language: sh
+  fast_finish: true
 
 sudo: false
 cache: pip
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  - >
+    if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      choco install python3
+      ln -s $(which py) /usr/bin/python3
+    fi
 
 install:
   - travis_retry python3 -m pip install -e .[test]


### PR DESCRIPTION
Hey,

I modified the Travis configuration slightly to also run the test suite on Windows. As you can see after merging this, some of the tests currently fail on Windows (they do on Travis and on my computer).

I'm not sure if the project officially supports Windows - the documentation doesn't mention anything about that as far as I can see. If it's not supported, just close this PR and maybe mention that somewhere. Otherwise I think it would be a good idea to have an overview of how the tests behave on Windows.

Let me know if you would rather have the Windows build as "allowed failure" so it doesn't cause the entire job to fail.