### PR TITLE
Added python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name="curio",
       extras_require={
           'test': tests_require,
       },
+      python_requires='>= 3.6',
       classifiers=[
           'Programming Language :: Python :: 3',
       ])


### PR DESCRIPTION
Projects should ideally declare which Python versions they support. Curio 1.0 dropped Python 3.5 support but that was not reflected in the metadata in any way, which leads to syntax errors when doing `pip install curio`. The damage is already done for Python 3.5 but when 3.6 support is eventually dropped, this will help avoid problems then.