### PR TITLE
Mutable default arguments can cause issues

### DIFF
--- a/curio/thread.py
+++ b/curio/thread.py
@@ -67,10 +67,10 @@ _locals = threading.local()
 
 class AsyncThread(object):
 
-    def __init__(self, target=None, args=(), kwargs={}, daemon=False):
+    def __init__(self, target=None, args=None, kwargs=None, daemon=False):
         self.target = target
-        self.args = args
-        self.kwargs = kwargs
+        self.args = args if args is not None else tuple()
+        self.kwargs = kwargs if kwargs is not None else {}
         self.daemon = daemon
 
         # The following attributes are provided to make a thread mimic a Task


### PR DESCRIPTION
Default arguments that are mutable are bad because they are the same object and one modification can affect the next call and cause unintended behavior. If this was the intended behavior, then at least a comment should be added stating that such behavior was intended.