### PR TITLE
Address pytest deprecation warning

### DIFF
--- a/curio/pytest_plugin.py
+++ b/curio/pytest_plugin.py
@@ -57,7 +57,7 @@ def pytest_configure(config):
 def pytest_pycollect_makeitem(collector, name, obj):
     """A pytest hook to collect coroutines in a test module."""
     if collector.funcnamefilter(name) and _is_coroutine(obj):
-        item = pytest.Function(name, parent=collector)
+        item = pytest.Function.from_parent(collector, name=name)
         if 'curio' in item.keywords:
             return list(collector._genfunctions(name, obj))
 


### PR DESCRIPTION
Here it is:

```
.venv/lib/python3.7/site-packages/curio/pytest_plugin.py:60
.venv/lib/python3.7/site-packages/curio/pytest_plugin.py:60
  /Users/sobolev/Documents/github/returns/.venv/lib/python3.7/site-packages/curio/pytest_plugin.py:60: PytestDeprecationWarning: direct construction of Function has been deprecated, please use Function.from_parent
    item = pytest.Function(name, parent=collector)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

I am not sure that it will work, let's find out!