### PR TITLE
Fixed pytest plugin wrapping functions too eagerly

### DIFF
--- a/curio/pytest_plugin.py
+++ b/curio/pytest_plugin.py
@@ -66,7 +66,7 @@ def pytest_pycollect_makeitem(collector, name, obj):
 def pytest_pyfunc_call(pyfuncitem):
     """Run curio marked test functions in a Curio kernel instead of a normal function call.
     """
-    if 'curio' in pyfuncitem.keywords:
+    if pyfuncitem.get_closest_marker('curio'):
         pyfuncitem.obj = wrap_in_sync(pyfuncitem.obj)
     yield
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,9 @@
+import pytest
+
+import curio
+
+
+@pytest.mark.filterwarnings('error::pytest.PytestUnhandledCoroutineWarning')
+@pytest.mark.curio
+async def test_coroutine_test():
+    await curio.sleep(0)


### PR DESCRIPTION
Using "keywords" here conflicts with the AnyIO pytest plugin.

Fixes #327.