### PR TITLE
Add missing sleep after sock.close() in tcp echo tests

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -730,6 +730,7 @@ def test_iterline(kernel, portno):
         await sock.recv(8)
         await sock.send(b'Msg1\nMsg2\nMsg3\n')
         await sock.close()
+        await sleep(0.1)
         await serv.cancel()
 
     async def main():

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -39,6 +39,7 @@ def test_tcp_echo(kernel):
         results.append(('client', resp))
         results.append('client close')
         await sock.close()
+        await sleep(0.1)
         await serv.cancel()
 
     async def main():

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -47,6 +47,7 @@ def test_tcp_echo(kernel, portno):
         results.append(('client', resp))
         results.append('client close')
         await sock.close()
+        await sleep(0.1)
 
     async def main():
         async with TaskGroup() as g:
@@ -109,6 +110,7 @@ def test_tcp_file_echo(kernel, portno):
         results.append(('client', resp))
         results.append('client close')
         await sock.close()
+        await sleep(0.1)
 
     async def main():
         async with TaskGroup() as g:
@@ -214,6 +216,7 @@ def test_fromfd_tcp_echo(kernel, portno):
         results.append(('client', resp))
         results.append('client close')
         await sock.close()
+        await sleep(0.1)
 
     async def main():
         async with TaskGroup() as g:


### PR DESCRIPTION
Commit fixing the following issue:

```
E       AssertionError: assert ['client start',\n 'handler start',\n 'recv wait',\n ('handler', b'Msg1'),\n 'recv wait',\n ('client', b'Msg1'),\n ('handler', b'Msg2'),\n 'recv wait',\n ('client', b'Msg2'),\n 'client close'] == ['client start',\n 'handler start',\n 'recv wait',\n ('handler', b'Msg1'),\n 'recv wait',\n ('client', b'Msg1'),\n ('handler', b'Msg2'),\n 'recv wait',\n ('client', b'Msg2'),\n 'client close',\n 'handler done']
E         Right contains one more item: 'handler done'
E         Full diff:
E           [
E            'client start',
E            'handler start',
E            'recv wait',
E            ('handler',
E             b'Msg1'),
E            'recv wait',
E            ('client',
E             b'Msg1'),
E            ('handler',
E             b'Msg2'),
E            'recv wait',
E            ('client',
E             b'Msg2'),
E            'client close',
E         -  'handler done',
E           ]

tests/test_network.py:54: AssertionError
```