### PR TITLE
Fix docs build

### DIFF
--- a/docs/customization.py
+++ b/docs/customization.py
@@ -1,7 +1,12 @@
 # Adapted from https://hg.python.org/cpython/file/default/Doc/tools/extensions/pyspecific.py .
 
-from sphinx import addnodes
-from sphinx.domains.python import PyModulelevel, PyClassmember
+from sphinx import addnodes, __version__
+
+if tuple(map(int,__version__.split('.'))) >= (4, 0, 0):
+    from sphinx.domains.python import PyAttribute, PyFunction
+else:
+    from sphinx.domains.python import PyModulelevel, PyClassmember
+    PyFunction, PyAttribute = PyModulelevel, PyClassmember
 
 
 class PyCoroutineMixin(object):
@@ -12,18 +17,18 @@ class PyCoroutineMixin(object):
         return ret
 
 
-class PyAsyncFunction(PyCoroutineMixin, PyModulelevel):
+class PyAsyncFunction(PyCoroutineMixin, PyFunction):
 
     def run(self):
         self.name = 'py:function'
-        return PyModulelevel.run(self)
+        return PyFunction.run(self)
 
 
-class PyAsyncMethod(PyCoroutineMixin, PyClassmember):
+class PyAsyncMethod(PyCoroutineMixin, PyAttribute):
 
     def run(self):
         self.name = 'py:method'
-        return PyClassmember.run(self)
+        return PyAttribute.run(self)
 
 
 def setup(app):

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1390,6 +1390,7 @@ The following functions are also available.  They accept the same arguments as t
 equivalents in the :mod:`subprocess` module:
 
 .. asyncfunction:: run(args, stdin=None, input=None, stdout=None, stderr=None, shell=False, check=False)
+   :noindex:
 
    Run a command in a subprocess.  Returns a :class:`subprocess.CompletedProcess` instance.
    If cancelled, the underlying process is terminated using the process ``kill()`` method.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -64,7 +64,7 @@ This program does two things at once::
         curio.run(parent)
 
 ``curio.spawn()`` launches a concurrent task. The ``join()`` method waits
-for it to finish and returns its result. The following output is produced::
+for it to finish and returns its result. The following output is produced:: console
 
     bash % python3 hello.py
     Getting around to doing my homework
@@ -141,7 +141,7 @@ Likewise, cancellation can be caught. For example::
             print("No go diggy die!")
             raise
 
-Now the program produces this output::
+Now the program produces this output:: console
 
     bash % python3 hello.py
     Getting around to doing my homework
@@ -153,7 +153,7 @@ Now the program produces this output::
     Are you done yet?
     We've got to go!
     No go diggy die!
-   bash %
+    bash %
 
 This is the basic gist of tasks. You can create
 tasks, join tasks, and cancel tasks.  
@@ -190,7 +190,7 @@ Running this code, you will either get output similar to this::
     T-minus 7
     Result: 1554
 
-or you will get this if the ``kid()`` took too long::
+or you will get this if the ``kid()`` took too long:: console
 
     Getting around to doing my homework
     T-minus 10
@@ -322,7 +322,7 @@ echo server::
         run(tcp_server, '', 25000, echo_client)
 
 Run this program and connect to it using ``nc`` or ``telnet``.  You'll
-see the program echoing back data to you::
+see the program echoing back data to you:: console
 
     bash % nc localhost 25000
     Hello                 (you type)


### PR DESCRIPTION
Signed-off-by: Harmouch101 <eng.mahmoudharmouch@gmail.com>

### What was wrong?

Related to Issue #343

### How was it fixed?
Based on the list of [deprecated](https://www.sphinx-doc.org/en/master/extdev/deprecated.html) modules in newer versions of `sphinx`, I did some tweaks to add support for sphinx>=4.0.0, as well as keeping backward compatibility with prior vesrions. Moreover, I fixed the warnings that are filed during the build process(Bonus).

```bash
~/curio/docs/curio2/docs/tutorial.rst:69: WARNING: Could not lex literal_block as "python3". Highlighting skipped.
~/curio/docs/curio2/docs/tutorial.rst:146: WARNING: Could not lex literal_block as "python3". Highlighting skipped.
~/curio/docs/curio2/docs/tutorial.rst:195: WARNING: Could not lex literal_block as "python3". Highlighting skipped.
~/curio/docs/curio2/docs/tutorial.rst:327: WARNING: Could not lex literal_block as "python3". Highlighting skipped.
```

#### Cute Animal Picture

:dog: 
