### PR TITLE
Fix for windows OSError raised when select is called with empty lists since python 3.10.5

### DIFF
--- a/curio/kernel.py
+++ b/curio/kernel.py
@@ -642,7 +642,9 @@ class Kernel(object):
                 except OSError as e:
                     # If there is nothing to select, windows throws an
                     # OSError, so just set events to an empty list.
-                    if e.errno != getattr(errno, 'WSAEINVAL', None):
+                    wsaeinval = getattr(errno, 'WSAEINVAL', None)
+                    einval = getattr(errno, 'EINVAL', None)
+                    if e.errno not in (wsaeinval, einval):
                         raise
                     events = []
 


### PR DESCRIPTION
python3.10 sets e.errno to 22 instead of 10022 so we need to check against both WSAEINVAL and EINVAL