### PR TITLE
Fixes #365: Don't pop an empty queue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ may have moved code there.  Many features of Curio were simply
 higher-level modules implemented on top of an existing core and can be
 added back to your code without much effort. -- Dave
 
+08/19/2024 Export Connection class to help with type hinting.
+
 04/11/2024 Removed undocumented ProcessPool and ThreadPool names.
 
 04/11/2024 Removed block_in_thread().  This functionality can be

--- a/README.rst
+++ b/README.rst
@@ -8,13 +8,18 @@ well as some advanced features such as support for structured
 concurrency. It works on Unix and Windows and has zero dependencies.
 You'll find it to be familiar, small, fast, and fun.
 
-Important Notice: October 25, 2022
-----------------------------------
-The Curio project is no longer making package releases.  I'm more than
-happy to accept bug reports and may continue to work on it from time
-to time as the mood strikes.  If you want the absolute latest version, you
-should vendor the source code from here. Curio has no dependencies
-other than the Python standard library.  --Dave
+CMAT Fork
+---------
+On December 21, 2025, the development of the original curio source code
+at https://github.com/dabeaz/curio officially ceased and the repository
+was made read-only.
+
+Consequently, this fork will focus on continued development of curio in
+support of projects at CANMETMaterials that rely on the curio async
+runtime, and upstreaming/backwards compatibility will no longer be a
+consideration for future development efforts.
+
+For further information please contact Mike Werezak <mike.werezak@nrcan-rncan.gc.ca>.
 
 Curio is Different
 ------------------

--- a/curio/channel.py
+++ b/curio/channel.py
@@ -4,7 +4,7 @@
 # Python objects on a stream.  Compatible with the Connection class in the
 # multiprocessing module, but rewritten for a purely asynchronous runtime.
 
-__all__ = ['Channel']
+__all__ = ['Channel', 'Connection']
 
 # -- Standard Library
 

--- a/curio/io.py
+++ b/curio/io.py
@@ -634,4 +634,3 @@ class SocketStream(StreamBase):
         except errors.CancelledError as e:
             e.bytes_written = nwritten
             raise
-

--- a/curio/monitor.py
+++ b/curio/monitor.py
@@ -125,7 +125,6 @@ class Monitor(object):
         '''
         Function to start the monitor
         '''
-        log.info('Starting Curio monitor at %s', self.address)
         self._closing = threading.Event()        
         self._ui_thread = threading.Thread(target=self.server, args=(), daemon=True)
         self._ui_thread.start()
@@ -142,6 +141,8 @@ class Monitor(object):
         # blocking indefinitaly on sock.accept()
         sock.settimeout(0.5)
         sock.bind(self.address)
+        self.address = sock.getsockname()
+        log.info('Starting Curio monitor at %s', self.address)
         sock.listen(1)
         with sock:
             while not self._closing.is_set():

--- a/curio/sched.py
+++ b/curio/sched.py
@@ -84,7 +84,7 @@ class SchedFIFO(SchedBase):
 
     def _kernel_wake(self, ntasks=1):
         tasks = []
-        while ntasks > 0:
+        while self._queue and ntasks > 0:
             task, = self._queue.popleft()
             if task:
                 tasks.append(task)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,1 @@
+# this is a hack so that buildpkg recognizes this package

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Curio is a coroutine-based library for concurrent systems programming.  No longe
 maintained as a PyPi project.  Latest version is available on GitHub. 
 """
 
-CURIO_VERSION = "1.6.1+cmat"
+CURIO_VERSION = "1.6.2+cmat"
 
 setup(name="curio",
       description="Curio",

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,13 @@ Curio is a coroutine-based library for concurrent systems programming.  No longe
 maintained as a PyPi project.  Latest version is available on GitHub. 
 """
 
+CURIO_VERSION = "1.6.1+cmat"
 
 setup(name="curio",
       description="Curio",
       long_description=long_description,
       license="BSD",
-      version="1.6",
+      version=CURIO_VERSION,
       author="David Beazley",
       author_email="dave@dabeaz.com",
       maintainer="David Beazley",

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1,0 +1,54 @@
+"""
+Copyright (C) Natural Resources Canada - All Rights Reserved.
+
+Unauthorized copying of this file, via any medium is strictly prohibited.
+Proprietary and confidential.
+
+| Author: Mike Werezak <mike.werezak@nrcan-rncan.gc.ca>
+| Created: 2026-03-01
+"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from curio import *
+from curio.sched import SchedFIFO
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestSchedFIFO:
+    def test_suspend_then_wake(self, kernel):
+        results = []
+        async def worker(sched):
+            results.append('suspend')
+            await sched.suspend()
+            results.append('worker_done')
+
+        async def waker(seconds):
+            sched = SchedFIFO()
+            await spawn(worker, sched)
+            results.append('sleep')
+            await sleep(seconds)
+            results.append('wake')
+            await sched.wake(1)
+            results.append('waker_done')
+
+        kernel.run(waker(1))
+        kernel.run()  # allow the worker to finish
+
+        assert results == [
+            'sleep',
+            'suspend',
+            'wake',
+            'waker_done',
+            'worker_done',
+        ]
+
+    def test_wait_when_queue_empty(self, kernel):
+        async def main():
+            sched = SchedFIFO()
+            await sched.wake(1)
+
+        kernel.run(main)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -694,6 +694,15 @@ class TestCondition:
 
         kernel.run(main)
 
+    # See <https://github.com/dabeaz/curio/issues/365>
+    def test_condition_notify_without_wait(self, kernel):
+        async def main():
+            c = Condition()
+            async with c:
+                await c.notify()
+
+        kernel.run(main)
+
 class TestUniversalEvent:
 
     def test_uevent_get_wait(self, kernel):


### PR DESCRIPTION
Fix IndexError from being raised inside the kernel by turning SchedFIFO wake into a no-op if there are no tasks waiting.

See discussion on #365.